### PR TITLE
fix: interest API 사용 중단 처리

### DIFF
--- a/src/main/java/com/virtukch/nest/interest/controller/InterestController.java
+++ b/src/main/java/com/virtukch/nest/interest/controller/InterestController.java
@@ -1,11 +1,14 @@
 package com.virtukch.nest.interest.controller;
 
 import com.virtukch.nest.interest.dto.InterestResponseDto;
-import com.virtukch.nest.interest.service.InterestService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -15,11 +18,12 @@ import java.util.List;
 @Tag(name = "Interest API", description = "관심 기술 스택 관련 API")
 public class InterestController {
 
-    private final InterestService interestService;
-
-//    @Operation(summary = "관심 기술 전체 조회", description = "모든 관심 기술 스택 정보를 조회합니다.")
-//    @GetMapping
-//    public List<InterestResponseDto> findAll() {
-//        return interestService.findAll();
-//    }
+    @Operation(summary = "관심 기술 전체 조회", description = "모든 관심 기술 스택 정보를 조회합니다.")
+    @GetMapping
+    @Deprecated
+    public ResponseEntity<List<InterestResponseDto>> findAll() {
+        return ResponseEntity.status(HttpStatus.GONE)
+                .header("Warning", "299 - \"This API is deprecated and no longer supported\"")
+                .build();
+    }
 }


### PR DESCRIPTION
fe측에서 에러메시지가 부재한 403 응답에 대해, 모두 로그아웃 처리를 하고 있기 때문에 그냥 주석처리를 하는 것이 아니라, 410 http Gone 에러 반환하게끔 수정하였습니다.