### PR TITLE
공지사항 전체 목록 조회 api 구현 및 저장 로직 약간 수정

### DIFF
--- a/src/main/java/com/virtukch/nest/notice/controller/NoticeController.java
+++ b/src/main/java/com/virtukch/nest/notice/controller/NoticeController.java
@@ -75,6 +75,41 @@ public class NoticeController {
         return ResponseEntity.ok(ApiResponseDto.success(noticeType, savedCount));
     }
 
+
+    @Operation(
+            summary = "공지사항 전체 조회",
+            description = """
+                    전체 공지사항 목록을 조회합니다.
+                    
+                    ## 페이지네이션
+                    - 페이지 번호: `?page=0` (기본값: 0, 첫 페이지)
+                    - 페이지 크기: `?size=10` (기본값: 10, 페이지당 10개 항목)
+                    
+                    ## 정렬
+                    - 기본 정렬: 게시일 내림차순(최신순)
+                    - 정렬 필드 변경: `?sort={필드명}`
+                    - 정렬 방향 변경: `?sort={필드명},{정렬방향}`
+                      - 예: `?sort=postDate,desc`
+                    
+                    ## 응답 형식
+                    응답은 다음 정보를 포함합니다:
+                    - 공지사항 목록
+                    - 전체 공지사항 수
+                    - 페이지 정보 (현재 페이지, 전체 페이지, 다음/이전 페이지 존재 여부 등)
+                    
+                    ## 사용 예시
+                    - `/api/v1/notices/일반공지?page=0&size=10&sort=postDate,desc`
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<NoticeListResponseDto> getNotices(
+            @PageableDefault(size = 10, sort = "postDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        log.info("공지사항 전체 조회");
+
+        NoticeListResponseDto responseDto = noticeService.getNotices(pageable);
+        return ResponseEntity.ok(responseDto);
+    }
+
     @Operation(
             summary = "공지사항 목록 조회",
             description = """

--- a/src/main/java/com/virtukch/nest/notice/service/NoticeService.java
+++ b/src/main/java/com/virtukch/nest/notice/service/NoticeService.java
@@ -39,7 +39,7 @@ public class NoticeService {
      * @throws InvalidNoticeTypeException 유효하지 않은 공지사항 유형이 있을 경우
      */
     @Transactional
-    public int saveNotices(NoticeRequestDto requestDto, String noticeType) {
+    public int ㅋ(NoticeRequestDto requestDto, String noticeType) {
         List<Map<String, Object>> notices = requestDto.getNotices();
 
         // 데이터 유효성 검사
@@ -69,6 +69,10 @@ public class NoticeService {
                     continue;
                 }
 
+                // 모든 공백 문자를 일반 공백으로 변환하고 연속된 것들을 하나로 줄임
+                String title = ((String) noticeData.get("title")).replaceAll("\\s+", " ");
+                noticeData.put("title", title);
+
                 Notice notice = buildNotice(noticeType, noticeData);
 
                 noticeRepository.save(notice);
@@ -84,6 +88,12 @@ public class NoticeService {
         log.info("공지사항 저장이 완료되었습니다. noticeType: {}, 총 {}개 중 {}개 저장됨", noticeType, notices.size(), savedCount);
 
         return savedCount;
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeListResponseDto getNotices(Pageable pageable) {
+        Page<Notice> noticePage = noticeRepository.findAll(pageable);
+        return buildListResponseDto(noticePage);
     }
 
     @Transactional(readOnly = true)
@@ -150,7 +160,7 @@ public class NoticeService {
         return value != null ? value.toString() : "";
     }
 
-    private static LocalDate stringToLocalDate(String dateString) {
+    private LocalDate stringToLocalDate(String dateString) {
         if (dateString == null || dateString.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/virtukch/nest/notice/service/NoticeService.java
+++ b/src/main/java/com/virtukch/nest/notice/service/NoticeService.java
@@ -39,7 +39,7 @@ public class NoticeService {
      * @throws InvalidNoticeTypeException 유효하지 않은 공지사항 유형이 있을 경우
      */
     @Transactional
-    public int ㅋ(NoticeRequestDto requestDto, String noticeType) {
+    public int saveNotices(NoticeRequestDto requestDto, String noticeType) {
         List<Map<String, Object>> notices = requestDto.getNotices();
 
         // 데이터 유효성 검사


### PR DESCRIPTION

- 공지사항 목록 전체 조회 api 추가
- 공지사항 저장 시 공지사항 제목(title)에 포함된 연속된 탭, 공백, 줄바꿈 문자 등을 하나의 공백으로 치환하는 로직 추가.