### PR TITLE
Feature/ji hyuk : 프로젝트 모집 게시판 지원 관리 기능 추가 및 코드 리팩토링

### DIFF
--- a/src/main/java/com/virtukch/nest/project/controller/ProjectController.java
+++ b/src/main/java/com/virtukch/nest/project/controller/ProjectController.java
@@ -1,7 +1,6 @@
 package com.virtukch.nest.project.controller;
 
 import com.virtukch.nest.auth.security.CustomUserDetails;
-import com.virtukch.nest.post.service.PostService;
 import com.virtukch.nest.project.dto.*;
 import com.virtukch.nest.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/virtukch/nest/project/controller/ProjectController.java
+++ b/src/main/java/com/virtukch/nest/project/controller/ProjectController.java
@@ -3,6 +3,8 @@ package com.virtukch.nest.project.controller;
 import com.virtukch.nest.auth.security.CustomUserDetails;
 import com.virtukch.nest.project.dto.*;
 import com.virtukch.nest.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -20,11 +22,27 @@ import java.util.List;
 @RequestMapping("/api/projects")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "[프로젝트 모집 게시판] 게시글 API", description = "게시글 CRUD 등 게시판 관련 API\n문의 : dlwlgur02@gmail.com")
 public class ProjectController {
 
     private final ProjectService projectService;
 
     // 프로젝트 생성
+    @Operation(
+        summary = "프로젝트 모집글 생성",
+        description = """
+            새로운 프로젝트 모집글을 생성합니다.
+
+            ## 요청 필드
+            - `projectTitle`: 제목 (필수)
+            - `projectDescription`: 상세 설명 (선택)
+            - `tags`: 태그 목록 (선택, 존재하는 태그만 가능)
+            - `parts`: 모집 역할 및 인원 리스트 (필수)
+
+            ✔️ 로그인된 사용자만 작성 가능  
+            ✔️ 성공 시 생성된 게시글의 URI를 Location 헤더로 반환
+            """
+    )
     @PostMapping("/new")
     public ResponseEntity<ProjectResponseDto> createProject(
             @AuthenticationPrincipal CustomUserDetails user,
@@ -38,12 +56,39 @@ public class ProjectController {
     }
 
     // 전체 프로젝트 조회
+    @Operation(
+        summary = "프로젝트 모집글 상세 조회",
+        description = """
+            특정 프로젝트 모집글의 상세 정보를 조회합니다.
+
+            - `projectId`를 경로 변수로 전달  
+            - 게시글 작성자, 설명, 모집 역할 등 포함
+            """
+    )
     @GetMapping("/{projectId}")
     public ResponseEntity<ProjectDetailResponseDto> getProjectDetail(@PathVariable Long projectId) {
         ProjectDetailResponseDto responseDto = projectService.getProjectDetail(projectId);
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(
+        summary = "전체 프로젝트 모집글 조회",
+        description = """
+            모든 프로젝트 모집글을 최신순으로 조회합니다.
+
+            ## 태그 필터링
+            - `?tags=JAVA&tags=SPRING` 등 다중 태그 필터 가능
+
+            ## 페이지네이션
+            - `page`: 페이지 번호 (0부터 시작)
+            - `size`: 페이지당 항목 수 (기본값: 10)
+
+            ## 정렬
+            - `sort=createdAt,desc` 등
+
+            ✔️ 태그가 없으면 전체 게시글 반환
+            """
+    )
     @GetMapping
     public ResponseEntity<ProjectListResponseDto> getProjects(
             @RequestParam(required = false) List<String> tags,
@@ -60,6 +105,22 @@ public class ProjectController {
 
 
     //프로젝트 업데이트
+    @Operation(
+        summary = "프로젝트 모집글 수정",
+        description = """
+            기존 프로젝트 모집글의 내용을 수정합니다.
+
+            ## 요청 필드 처리 방식
+            - `projectTitle`: null 또는 생략 시 제목 변경 없음 / 빈 문자열은 허용하지 않음
+            - `projectDescription`: null 또는 생략 시 본문 변경 없음 / 빈 문자열 입력 시 본문 삭제 처리
+            - `tags`: null 또는 생략 시 태그 변경 없음 / 빈 배열 입력 시 모든 태그 제거
+            - `parts`: null 또는 생략 시 모집 인원 및 역할 변경 없음 / 새 배열 입력 시 전체 교체
+            - `imageUrlsToDelete`: 삭제할 이미지 URL 리스트 / 존재하지 않는 이미지 URL 전달 시 무시
+
+            ✔️ 작성자 본인만 수정 가능  
+            ✔️ 수정 가능한 필드는 `ProjectRequestDto` 참고
+            """
+    )
     @PatchMapping("/{projectId}")
     public ResponseEntity<ProjectResponseDto> updateProject(
             @AuthenticationPrincipal CustomUserDetails user,
@@ -71,6 +132,15 @@ public class ProjectController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(
+        summary = "프로젝트 모집글 삭제",
+        description = """
+            프로젝트 모집글을 삭제합니다.
+
+            - 작성자 본인만 삭제 가능  
+            - 삭제된 게시글은 조회할 수 없습니다.
+            """
+    )
     @DeleteMapping("/{projectId}")
     public ResponseEntity<ProjectResponseDto> deleteProject(@AuthenticationPrincipal CustomUserDetails user,
                                                             @PathVariable Long projectId) {
@@ -81,6 +151,35 @@ public class ProjectController {
     }
 
 
+    @Operation(
+        summary = "게시글 검색",
+        description = """
+            키워드를 사용하여 게시글을 검색합니다.
+
+            ## 검색 키워드
+            - `keyword`: 검색할 키워드
+
+            ## 검색 타입
+            - `searchType`: 검색 타입 (ALL, TITLE, CONTENT)
+                - ALL: 제목과 내용에서 검색 (기본값)
+                - TITLE: 제목에서만 검색
+                - CONTENT: 내용에서만 검색
+
+            ## 태그 필터링
+            - `?tags=JAVA&tags=SPRING` 등으로 전달
+
+            ## 페이지네이션
+            - `page`: 페이지 번호 (0부터 시작)
+            - `size`: 페이지당 항목 수 (기본값: 10)
+
+            ## 정렬
+            - 단일: `?sort=createdAt,desc`
+            - 다중: `?sort=viewCount,desc&sort=createdAt,desc`
+
+            ## 전체 사용 예시
+            - `/api/v1/posts/search?keyword=스프링&searchType=TITLE&page=0&size=10&sort=createdAt,desc&tags=JAVA`
+            """
+    )
     @GetMapping("/search")
     public ResponseEntity<ProjectListResponseDto> searchProjects(
             @RequestParam String keyword,

--- a/src/main/java/com/virtukch/nest/project/controller/ProjectV2Controller.java
+++ b/src/main/java/com/virtukch/nest/project/controller/ProjectV2Controller.java
@@ -25,6 +25,16 @@ import java.net.URI;
 public class ProjectV2Controller {
     private final ProjectService projectService;
 
+    @Operation(
+        summary = "프로젝트 모집글 생성 (이미지 포함)",
+        description = """
+            이미지를 포함한 프로젝트 모집글을 생성합니다.
+            ✔️ 로그인된 사용자만 작성 가능
+            ✔️ multipart/form-data 형식으로 요청
+            ✔️ 성공 시 생성된 게시글의 URI를 Location 헤더로 반환합니다.
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ProjectResponseDto> createProject(
             @AuthenticationPrincipal CustomUserDetails user,
@@ -39,6 +49,16 @@ public class ProjectV2Controller {
                 .body(responseDto);
     }
 
+    @Operation(
+        summary = "프로젝트 모집글 수정 (이미지 포함)",
+        description = """
+            이미지를 포함한 프로젝트 모집글을 수정합니다.
+            ✔️ 작성자 본인만 수정 가능
+            ✔️ multipart/form-data 형식으로 요청
+            ✔️ 수정 가능한 필드는 ProjectWithImagesRequestDto 참고
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @PatchMapping(path = "/{projectId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ProjectResponseDto> updateProject(@AuthenticationPrincipal CustomUserDetails user,
                                                             @PathVariable Long projectId,

--- a/src/main/java/com/virtukch/nest/project/dto/ProjectMemberSimpleDto.java
+++ b/src/main/java/com/virtukch/nest/project/dto/ProjectMemberSimpleDto.java
@@ -11,5 +11,4 @@ public class ProjectMemberSimpleDto {
     private ProjectMember.Role role;
     private Long memberId;
     private String memberName;
-    private ProjectMember.ApplicationStatus applicationStatus;
 }

--- a/src/main/java/com/virtukch/nest/project/dto/ProjectRequestDto.java
+++ b/src/main/java/com/virtukch/nest/project/dto/ProjectRequestDto.java
@@ -12,7 +12,6 @@ public class ProjectRequestDto {
     @NotBlank(message = "모집글 제목은 비어 있을 수 없습니다.")
     private String projectTitle;
     private String projectDescription;
-    private int maxMember;
     private boolean isRecruiting;
     private List<String> tags;
     private Map<ProjectMember.Part, Integer> partCounts;

--- a/src/main/java/com/virtukch/nest/project/service/ProjectService.java
+++ b/src/main/java/com/virtukch/nest/project/service/ProjectService.java
@@ -49,7 +49,8 @@ public class ProjectService {
         String projectTitle = requestDto.getProjectTitle();
         log.info("[프로젝트 모집글 작성 시작] title={}, memberId={}", projectTitle, memberId);
 
-        Project project = projectRepository.save(Project.createProject(memberId, projectTitle, requestDto.getProjectDescription(), requestDto.getMaxMember()));
+        int maxMember = requestDto.getPartCounts().values().stream().mapToInt(Integer::intValue).sum();
+        Project project = projectRepository.save(Project.createProject(memberId, projectTitle, requestDto.getProjectDescription(), maxMember));
 
         saveProjectTags(project, requestDto.getTags());
 
@@ -68,7 +69,8 @@ public class ProjectService {
     public ProjectResponseDto createProject(Long memberId, ProjectWithImagesRequestDto requestDto) {
         String title = requestDto.getProjectTitle();
         log.info("[모집글 생성 시작] title={}, memberId={}", title, memberId);
-        Project project = projectRepository.save(Project.createProject(memberId, title, requestDto.getProjectDescription(), requestDto.getMaxMember()));
+        int maxMember = requestDto.getPartCounts().values().stream().mapToInt(Integer::intValue).sum();
+        Project project = projectRepository.save(Project.createProject(memberId, title, requestDto.getProjectDescription(), maxMember));
 
         saveProjectTags(project, requestDto.getTags());
 
@@ -133,9 +135,10 @@ public class ProjectService {
     @Transactional
     public ProjectResponseDto updateProject(Long projectId, Long memberId, ProjectRequestDto requestDto) {
         Project project = validateProjectOwnershipAndGet(projectId, memberId);
+        int maxMember = requestDto.getPartCounts().values().stream().mapToInt(Integer::intValue).sum();
         project.updateProject(requestDto.getProjectTitle(),
                 requestDto.getProjectDescription(),
-                requestDto.getMaxMember(),
+                maxMember,
                 requestDto.isRecruiting());
 
         projectTagRepository.deleteAllByProjectId(projectId);

--- a/src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java
+++ b/src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java
@@ -1,0 +1,34 @@
+package com.virtukch.nest.project_application.controller;
+
+import com.virtukch.nest.auth.security.CustomUserDetails;
+import com.virtukch.nest.project_application.dto.ProjectApplicationRequestDto;
+import com.virtukch.nest.project_application.dto.ProjectApplicationResponseDto;
+import com.virtukch.nest.project_application.service.ProjectApplicationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/projects")
+public class ProjectApplicationController {
+    private final ProjectApplicationService projectApplicationService;
+
+    @PostMapping("/{projectId}/apply")
+    public ResponseEntity<ProjectApplicationResponseDto> projectApplicationApply(@AuthenticationPrincipal CustomUserDetails user,
+                                      @PathVariable Long projectId,
+                                      @RequestBody ProjectApplicationRequestDto requestDto) {
+        Long memberId = user.getMember().getMemberId();
+        ProjectApplicationResponseDto responseDto = projectApplicationService.applyToProject(projectId, memberId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{projectId}/applications")
+    public ResponseEntity<List<ProjectApplicationResponseDto>> getProjectApplications(@PathVariable Long projectId) {
+        List<ProjectApplicationResponseDto> applications = projectApplicationService.getApplicationsByProject(projectId);
+        return ResponseEntity.ok(applications);
+    }
+}

--- a/src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java
+++ b/src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java
@@ -4,19 +4,32 @@ import com.virtukch.nest.auth.security.CustomUserDetails;
 import com.virtukch.nest.project_application.dto.ProjectApplicationRequestDto;
 import com.virtukch.nest.project_application.dto.ProjectApplicationResponseDto;
 import com.virtukch.nest.project_application.service.ProjectApplicationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/projects")
+@Tag(name = "[프로젝트 모집글 지원 관리] 지원 처리 API", description = "프로젝트 모집글에 지원하고, 지원 현황(지원자 목록 등)을 조회할 수 있는 API입니다.\n문의 : dlwlgur02@gmail.com")
 public class ProjectApplicationController {
     private final ProjectApplicationService projectApplicationService;
 
+    @Operation(
+        summary = "프로젝트 모집글에 지원",
+        description = """
+            로그인된 사용자가 해당 프로젝트 모집글에 지원합니다.
+            ✔️ 같은 프로젝트에 중복 지원 불가
+            ✔️ 지원 시 역할 및 자기소개 등 정보 포함
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @PostMapping("/{projectId}/apply")
     public ResponseEntity<ProjectApplicationResponseDto> projectApplicationApply(@AuthenticationPrincipal CustomUserDetails user,
                                       @PathVariable Long projectId,
@@ -26,9 +39,20 @@ public class ProjectApplicationController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(
+        summary = "프로젝트 모집글 지원자 목록 조회",
+        description = """
+            특정 프로젝트에 지원한 모든 지원자의 목록을 조회합니다.
+            ✔️ 작성자 본인만 조회 가능
+            ✔️ 지원자 이름, 역할, 상태 등 포함
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @GetMapping("/{projectId}/applications")
     public ResponseEntity<List<ProjectApplicationResponseDto>> getProjectApplications(@PathVariable Long projectId) {
         List<ProjectApplicationResponseDto> applications = projectApplicationService.getApplicationsByProject(projectId);
         return ResponseEntity.ok(applications);
     }
+
+
 }

--- a/src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationRequestDto.java
+++ b/src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationRequestDto.java
@@ -1,0 +1,12 @@
+package com.virtukch.nest.project_application.dto;
+
+
+import com.virtukch.nest.project_member.model.ProjectMember;
+import lombok.Getter;
+
+
+@Getter
+public class ProjectApplicationRequestDto {
+    private Long projectId;
+    private ProjectMember.Part part;
+}

--- a/src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationResponseDto.java
+++ b/src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationResponseDto.java
@@ -1,0 +1,21 @@
+package com.virtukch.nest.project_application.dto;
+
+import com.virtukch.nest.project_application.model.ProjectApplication;
+import com.virtukch.nest.project_member.model.ProjectMember;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectApplicationResponseDto {
+    private Long applicationId;
+    private Long memberId;
+    private String memberName;
+    private ProjectMember.Part part;
+    private ProjectApplication.ApplicationStatus status;
+    private LocalDateTime appliedAt;
+}

--- a/src/main/java/com/virtukch/nest/project_application/dto/converter/ProjectApplicationDtoConverter.java
+++ b/src/main/java/com/virtukch/nest/project_application/dto/converter/ProjectApplicationDtoConverter.java
@@ -1,0 +1,17 @@
+package com.virtukch.nest.project_application.dto.converter;
+
+import com.virtukch.nest.project_application.dto.ProjectApplicationResponseDto;
+import com.virtukch.nest.project_application.model.ProjectApplication;
+
+public class ProjectApplicationDtoConverter {
+    public static ProjectApplicationResponseDto toResponseDto(ProjectApplication application, String memberName) {
+        return ProjectApplicationResponseDto.builder()
+                .applicationId(application.getApplicationId())
+                .memberId(application.getMemberId())
+                .memberName(memberName)
+                .part(application.getPart())
+                .status(application.getStatus())
+                .appliedAt(application.getAppliedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/virtukch/nest/project_application/model/ProjectApplication.java
+++ b/src/main/java/com/virtukch/nest/project_application/model/ProjectApplication.java
@@ -1,0 +1,36 @@
+package com.virtukch.nest.project_application.model;
+
+import com.virtukch.nest.project_member.model.ProjectMember;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProjectApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long applicationId;
+
+    private Long projectId;
+
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectMember.Part part;
+
+    @Enumerated(EnumType.STRING)
+    private ApplicationStatus status;
+
+    private LocalDateTime appliedAt;
+
+    public enum ApplicationStatus {
+        WAITING,
+        APPROVED,
+        REJECTED
+    }
+}

--- a/src/main/java/com/virtukch/nest/project_application/repository/ProjectApplicationRepository.java
+++ b/src/main/java/com/virtukch/nest/project_application/repository/ProjectApplicationRepository.java
@@ -1,0 +1,14 @@
+package com.virtukch.nest.project_application.repository;
+
+import com.virtukch.nest.project_application.model.ProjectApplication;
+import com.virtukch.nest.project_member.model.ProjectMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectApplicationRepository extends JpaRepository<ProjectApplication, Long> {
+    List<ProjectApplication> findByProjectId(Long projectId);
+    List<ProjectApplication> findByMemberId(Long memberId);
+    Optional<ProjectApplication> findByProjectIdAndMemberIdAndPart(Long projectId, Long memberId, ProjectMember.Part part);
+}

--- a/src/main/java/com/virtukch/nest/project_application/service/ProjectApplicationService.java
+++ b/src/main/java/com/virtukch/nest/project_application/service/ProjectApplicationService.java
@@ -1,0 +1,57 @@
+package com.virtukch.nest.project_application.service;
+
+import com.virtukch.nest.project_application.dto.ProjectApplicationRequestDto;
+import com.virtukch.nest.project_application.dto.ProjectApplicationResponseDto;
+import com.virtukch.nest.project_application.dto.converter.ProjectApplicationDtoConverter;
+import com.virtukch.nest.project_application.model.ProjectApplication;
+import com.virtukch.nest.project_application.repository.ProjectApplicationRepository;
+import com.virtukch.nest.member.model.Member;
+import com.virtukch.nest.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ProjectApplicationService {
+
+    private final ProjectApplicationRepository projectApplicationRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public ProjectApplicationResponseDto applyToProject(Long projectId, Long memberId, ProjectApplicationRequestDto requestDto) {
+        // 중복 지원 방지
+        if (projectApplicationRepository.findByProjectIdAndMemberIdAndPart(projectId, memberId, requestDto.getPart()).isPresent()) {
+            throw new IllegalStateException("이미 지원한 파트입니다.");
+        }
+
+        ProjectApplication application = ProjectApplication.builder()
+                .projectId(projectId)
+                .memberId(memberId)
+                .part(requestDto.getPart())
+                .status(ProjectApplication.ApplicationStatus.WAITING)
+                .appliedAt(LocalDateTime.now())
+                .build();
+
+        projectApplicationRepository.save(application);
+
+        Member member = memberRepository.findById(memberId).orElse(null);
+
+        return ProjectApplicationDtoConverter.toResponseDto(application, member != null ? member.getMemberName() : "알 수 없음");
+    }
+
+    @Transactional
+    public List<ProjectApplicationResponseDto> getApplicationsByProject(Long projectId) {
+        List<ProjectApplication> applications = projectApplicationRepository.findByProjectId(projectId);
+
+        return applications.stream().map(app -> {
+            Member member = memberRepository.findById(app.getMemberId()).orElse(null);
+            return ProjectApplicationDtoConverter.toResponseDto(app, member != null ? member.getMemberName() : "알 수 없음");
+        }).toList();
+    }
+}

--- a/src/main/java/com/virtukch/nest/project_member/controller/ProjectMemberController.java
+++ b/src/main/java/com/virtukch/nest/project_member/controller/ProjectMemberController.java
@@ -2,6 +2,9 @@ package com.virtukch.nest.project_member.controller;
 
 
 import com.virtukch.nest.project_member.model.ProjectMember;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,11 +13,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Arrays;
 import java.util.List;
-
+@Tag(name = "[프로젝트 모집 게시판] 역할 API", description = "프로젝트 참여 역할 관련 API\n문의 : dlwlgur02@gmail.com")
 @RestController
 @RequestMapping("/api/project-members")
 @RequiredArgsConstructor
 public class ProjectMemberController {
+    @Operation(
+        summary = "프로젝트 역할 목록 조회",
+        description = """
+            프로젝트 참여자의 역할(Enum)을 조회합니다.
+            ✔️ 프론트엔드, 백엔드, 디자이너 등
+            ✔️ 클라이언트에서 역할 선택용으로 사용
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
     @GetMapping
     public ResponseEntity<List<String>> getPartEnums() {
         List<String> parts = Arrays.stream(ProjectMember.Part.values())

--- a/src/main/java/com/virtukch/nest/project_member/model/ProjectMember.java
+++ b/src/main/java/com/virtukch/nest/project_member/model/ProjectMember.java
@@ -27,8 +27,6 @@ public class ProjectMember {
     @Enumerated(EnumType.STRING)
     private Part part; // 백엔드, 프론트엔드 등
 
-    @Enumerated(EnumType.STRING)
-    private ApplicationStatus applicationStatus = ApplicationStatus.WAITING;
 
     private boolean isApproved;
 
@@ -38,12 +36,6 @@ public class ProjectMember {
 
     public enum Part {
         BACKEND, FRONTEND, PM, DESIGN, AI, ETC
-    }
-
-    public enum ApplicationStatus {
-        WAITING,    // 요청만 된 상태
-        APPROVED,   // 승인됨
-        REJECTED    // 거절됨
     }
 
     // 유효성 검사 메서드 (DTO or Service 단에서 사용 가능)


### PR DESCRIPTION
## 지원 관리 기능 
- 현재 projectId를 기준으로 지원하기 기능, 조회하기 기능만 구현이 되어있음
- 수락 및 거절 기능 추가 예정

---
## 코드 리팩토링
- 프로젝트 생성 시 maxMember의 값을 수기로 적어주는 방식이었음
- projectMembers의 크기에 따라 maxMember의 값을 내부적으로 할당해주도록 수정함.

**createProject json코드 중 현재 모집하고싶은 파트별 멤버 수 설정**
``` json
  "partCounts": {
    "FRONTEND": 1,
    "BACKEND": 2,
    "PM": 1
  }
```

**getProjectDetail 의 반환값 중 파트별 현황 조회 결과**
``` json
 "projectMembers": [
        {
            "part": "FRONTEND",
            "role": "MEMBER",
            "memberId": null,
            "memberName": null
        },
        {
            "part": "BACKEND",
            "role": "MEMBER",
            "memberId": null,
            "memberName": null
        },
        {
            "part": "BACKEND",
            "role": "MEMBER",
            "memberId": null,
            "memberName": null
        },
        {
            "part": "PM",
            "role": "LEADER",
            "memberId": 1,
            "memberName": "김채호"
        }
    ]
```
-> 현재 maxMember의 수를 따로 반환해서 건네주는 api는 없음. 