### PR TITLE
fix(notice): 날짜 포맷 파싱 로직 개선

### DIFF
--- a/src/main/java/com/virtukch/nest/comment/controller/CommentController.java
+++ b/src/main/java/com/virtukch/nest/comment/controller/CommentController.java
@@ -22,6 +22,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -53,8 +56,9 @@ public class CommentController {
 
     @CommentListOperation
     @GetMapping
-    public ResponseEntity<CommentListResponseDto> getCommentList(@PathVariable BoardType boardType, @PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.getCommentList(boardType, postId));
+    public ResponseEntity<CommentListResponseDto> getCommentList(@PathVariable BoardType boardType, @PathVariable Long postId,
+                                                                 @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(commentService.getCommentList(boardType, postId ,pageable));
     }
 
     @Operation(

--- a/src/main/java/com/virtukch/nest/comment/dto/CommentListResponseDto.java
+++ b/src/main/java/com/virtukch/nest/comment/dto/CommentListResponseDto.java
@@ -1,5 +1,6 @@
 package com.virtukch.nest.comment.dto;
 
+import com.virtukch.nest.common.dto.PageInfoDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,5 +13,6 @@ import java.util.List;
 public class CommentListResponseDto {
     private List<CommentResponseDto> comments;
     private int totalCount;
+    private PageInfoDto pageInfo;
 }
 

--- a/src/main/java/com/virtukch/nest/comment/dto/converter/CommentDtoConverter.java
+++ b/src/main/java/com/virtukch/nest/comment/dto/converter/CommentDtoConverter.java
@@ -23,6 +23,7 @@ public class CommentDtoConverter {
                 )
                 .createdAt(timeFormat(comment.getCreatedAt()))
                 .updatedAt(timeFormat(comment.getUpdatedAt()))
+                .parentId(comment.getParentId())
                 .isDeleted(comment.isDeleted())
                 .likeCount(comment.getLikeCount())
                 .dislikeCount(comment.getDislikeCount())
@@ -42,7 +43,7 @@ public class CommentDtoConverter {
                 .totalCount(comments.size())
                 .build();
     }
-    
+
     private static String timeFormat(LocalDateTime dateTime) {
         return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"));
     }

--- a/src/main/java/com/virtukch/nest/comment/dto/converter/CommentDtoConverter.java
+++ b/src/main/java/com/virtukch/nest/comment/dto/converter/CommentDtoConverter.java
@@ -4,7 +4,9 @@ import com.virtukch.nest.comment.dto.CommentDeleteResponseDto;
 import com.virtukch.nest.comment.dto.CommentListResponseDto;
 import com.virtukch.nest.comment.dto.CommentResponseDto;
 import com.virtukch.nest.comment.model.Comment;
+import com.virtukch.nest.common.dto.PageInfoDto;
 import com.virtukch.nest.post.dto.AuthorDto;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -37,10 +39,11 @@ public class CommentDtoConverter {
                 .build();
     }
 
-    public static CommentListResponseDto toCommentList(List<CommentResponseDto> comments) {
+    public static CommentListResponseDto toCommentList(List<CommentResponseDto> comments, Page<Comment> page) {
         return CommentListResponseDto.builder()
                 .comments(comments)
                 .totalCount(comments.size())
+                .pageInfo(PageInfoDto.create(page))
                 .build();
     }
 

--- a/src/main/java/com/virtukch/nest/comment/repository/CommentRepository.java
+++ b/src/main/java/com/virtukch/nest/comment/repository/CommentRepository.java
@@ -2,17 +2,44 @@ package com.virtukch.nest.comment.repository;
 
 import com.virtukch.nest.comment.model.BoardType;
 import com.virtukch.nest.comment.model.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByBoardTypeAndPostIdOrderByCreatedAtAsc(BoardType boardType, Long postId);
+
+    // 특정 게시글의 최상위 댓글들만 페이징하여 조회 (parentId가 null인 댓글들)
+    @Query("""
+            SELECT c FROM Comment c 
+            WHERE c.boardType = :boardType 
+            AND c.postId = :postId 
+            AND c.parentId IS NULL
+            ORDER BY c.createdAt ASC
+            """)
+    Page<Comment> findRootCommentsPaged(
+            @Param("boardType") BoardType boardType,
+            @Param("postId") Long postId,
+            Pageable pageable);
+
+    @Query("""
+            SELECT c FROM Comment c 
+            WHERE c.boardType = :boardType 
+            AND c.postId = :postId 
+            AND c.parentId IN :rootIds
+            ORDER BY c.createdAt ASC
+            """)
+    List<Comment> findDirectRepliesByParentIds(
+            @Param("boardType") BoardType boardType,
+            @Param("postId") Long postId,
+            @Param("rootIds") List<Long> parentIds);
+
     void deleteAllByPostId(Long postId);
+
     Optional<Comment> findById(Long commentId);
 
     boolean existsByParentId(Long parentId);

--- a/src/main/java/com/virtukch/nest/comment/service/CommentService.java
+++ b/src/main/java/com/virtukch/nest/comment/service/CommentService.java
@@ -131,6 +131,9 @@ public class CommentService {
     private List<CommentResponseDto> buildFlatTreeStructure(List<Comment> comments, Map<Long, CommentResponseDto> responseMap) {
         List<CommentResponseDto> rootComments = new ArrayList<>();
 
+        Map<Long, Comment> commentMap = comments.stream()
+                .collect(Collectors.toMap(Comment::getCommentId, c -> c));
+
         // 최상위 댓글들을 찾기
         for (Comment comment : comments) {
             if (comment.getParentId() == null) {
@@ -141,7 +144,7 @@ public class CommentService {
         // 각 대댓글에 대해 최상위 부모를 찾아서 해당 부모의 children에 추가
         for (Comment comment : comments) {
             if (comment.getParentId() != null) {
-                Long rootParentId = findRootParentId(comment, comments);
+                Long rootParentId = findRootParentId(comment, commentMap);
                 CommentResponseDto rootParent = responseMap.get(rootParentId);
                 CommentResponseDto replyDto = responseMap.get(comment.getCommentId());
 
@@ -162,10 +165,7 @@ public class CommentService {
     /**
      * 주어진 댓글의 최상위 부모 댓글 ID를 찾습니다.
      */
-    private Long findRootParentId(Comment comment, List<Comment> allComments) {
-        Map<Long, Comment> commentMap = allComments.stream()
-                .collect(Collectors.toMap(Comment::getCommentId, c -> c));
-
+    private Long findRootParentId(Comment comment, Map<Long, Comment> commentMap) {
         Comment current = comment;
         while (current.getParentId() != null) {
             Comment parent = commentMap.get(current.getParentId());

--- a/src/main/java/com/virtukch/nest/notice/service/NoticeService.java
+++ b/src/main/java/com/virtukch/nest/notice/service/NoticeService.java
@@ -164,9 +164,12 @@ public class NoticeService {
         if (dateString == null || dateString.isEmpty()) {
             return null;
         }
+
+        String normalizedDate = dateString.replace(".", "-");
+
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-            return LocalDate.parse(dateString, formatter);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            return LocalDate.parse(normalizedDate, formatter);
         } catch (DateTimeParseException e) {
             throw new InvalidDateFormatException(dateString, e);
         }


### PR DESCRIPTION
- 소중대 사업단 공지사항의 형식이 살짝 달라서 손봤습니다.
- 대댓글에 대댓글이 달리면 무한으로 트리가 깊어지는 문제 해결
- 댓글 페이지네이션 기능 구현 (최상위 댓글 기준으로 페이지네이션. 대댓글의 경우에는 페이지네이션 X)