### PR TITLE
feat: 채팅방 멤버 입장/퇴장 API 구현 및 Swagger 문서화

### DIFF
--- a/src/main/java/com/virtukch/nest/chatting_room/controller/ChattingRoomController.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/controller/ChattingRoomController.java
@@ -45,7 +45,7 @@ public class ChattingRoomController {
 
     @Operation(
         summary = "채팅방 이름 수정",
-        description = "인증된 사용자가 특정 채팅방의 이름을 수정합니다. 수정 권한은 해당 채팅방에 대한 접근 권한이 있는 사용자로 제한됩니다.",
+        description = "인증된 사용자가 특정 채팅방의 이름을 수정합니다.",
         security = @SecurityRequirement(name = "bearerAuth"),
         responses = {
             @ApiResponse(
@@ -67,7 +67,7 @@ public class ChattingRoomController {
 
     @Operation(
         summary = "채팅방 삭제",
-        description = "인증된 사용자가 특정 채팅방을 삭제합니다. 삭제 권한은 해당 채팅방에 대한 접근 권한이 있는 사용자로 제한됩니다.",
+        description = "인증된 사용자가 특정 채팅방을 삭제합니다.",
         security = @SecurityRequirement(name = "bearerAuth"),
         responses = {
             @ApiResponse(

--- a/src/main/java/com/virtukch/nest/chatting_room/controller/ChattingRoomController.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/controller/ChattingRoomController.java
@@ -1,0 +1,86 @@
+package com.virtukch.nest.chatting_room.controller;
+
+import com.virtukch.nest.chatting_room.dto.ChattingRoomRequestDto;
+import com.virtukch.nest.chatting_room.dto.ChattingRoomResponseDto;
+import com.virtukch.nest.chatting_room.service.ChattingRoomService;
+import com.virtukch.nest.auth.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/chatting-room")
+@RequiredArgsConstructor
+public class ChattingRoomController {
+
+    private final ChattingRoomService chattingRoomService;
+
+    @Operation(
+        summary = "채팅방 생성",
+        description = "인증된 사용자가 새로운 채팅방을 생성합니다. 채팅방 이름은 필수이며, 생성자 정보는 인증된 사용자로부터 파생됩니다.",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "채팅방 생성 성공",
+                content = @Content(schema = @Schema(implementation = ChattingRoomResponseDto.class))
+            )
+        }
+    )
+    @PostMapping
+    public ResponseEntity<ChattingRoomResponseDto> createRoom(
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @RequestBody ChattingRoomRequestDto chattingRoomRequestDto) {
+        ChattingRoomResponseDto chattingRoomResponseDto = chattingRoomService.createNewChattingRoomWithName(
+            chattingRoomRequestDto);
+        return ResponseEntity.ok(chattingRoomResponseDto);
+    }
+
+    @Operation(
+        summary = "채팅방 이름 수정",
+        description = "인증된 사용자가 특정 채팅방의 이름을 수정합니다. 수정 권한은 해당 채팅방에 대한 접근 권한이 있는 사용자로 제한됩니다.",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "채팅방 이름 수정 성공",
+                content = @Content(schema = @Schema(implementation = ChattingRoomResponseDto.class))
+            )
+        }
+    )
+    @PatchMapping("/{chattingRoomId}")
+    public ResponseEntity<ChattingRoomResponseDto> updateRoomName(
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @Parameter(name = "chattingRoomId", description = "수정할 채팅방 ID") @PathVariable("chattingRoomId") Long chattingRoomId,
+        @RequestBody ChattingRoomRequestDto chattingRoomRequestDto) {
+        ChattingRoomResponseDto chattingRoomResponseDto = chattingRoomService.updateChattingRoomNameById(
+            chattingRoomId, chattingRoomRequestDto);
+        return ResponseEntity.ok(chattingRoomResponseDto);
+    }
+
+    @Operation(
+        summary = "채팅방 삭제",
+        description = "인증된 사용자가 특정 채팅방을 삭제합니다. 삭제 권한은 해당 채팅방에 대한 접근 권한이 있는 사용자로 제한됩니다.",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {
+            @ApiResponse(
+                responseCode = "204",
+                description = "채팅방 삭제 성공"
+            )
+        }
+    )
+    @DeleteMapping("/{chattingRoomId}")
+    public ResponseEntity<Void> deleteRoom(
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @Parameter(name = "chattingRoomId", description = "삭제할 채팅방 ID") @PathVariable("chattingRoomId") Long chattingRoomId) {
+        chattingRoomService.deleteChattingRoomById(chattingRoomId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/virtukch/nest/chatting_room/dto/ChattingRoomRequestDto.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/dto/ChattingRoomRequestDto.java
@@ -1,0 +1,14 @@
+package com.virtukch.nest.chatting_room.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChattingRoomRequestDto {
+    private String chattingRoomName;
+}

--- a/src/main/java/com/virtukch/nest/chatting_room/dto/ChattingRoomResponseDto.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/dto/ChattingRoomResponseDto.java
@@ -1,0 +1,19 @@
+package com.virtukch.nest.chatting_room.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChattingRoomResponseDto {
+    private Long chattingRoomId;
+    private String chattingRoomName;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastChattedAt;
+}

--- a/src/main/java/com/virtukch/nest/chatting_room/model/ChattingRoom.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/model/ChattingRoom.java
@@ -1,0 +1,26 @@
+package com.virtukch.nest.chatting_room.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChattingRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chattingRoomId;
+
+    private String chattingRoomName;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastChattedAt;
+}

--- a/src/main/java/com/virtukch/nest/chatting_room/repository/ChattingRoomRepository.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/repository/ChattingRoomRepository.java
@@ -1,0 +1,10 @@
+package com.virtukch.nest.chatting_room.repository;
+
+import com.virtukch.nest.chatting_room.model.ChattingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long> {
+
+}

--- a/src/main/java/com/virtukch/nest/chatting_room/service/ChattingRoomService.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/service/ChattingRoomService.java
@@ -1,0 +1,57 @@
+package com.virtukch.nest.chatting_room.service;
+
+import com.virtukch.nest.chatting_room.dto.ChattingRoomRequestDto;
+import com.virtukch.nest.chatting_room.dto.ChattingRoomResponseDto;
+import com.virtukch.nest.chatting_room.model.ChattingRoom;
+import com.virtukch.nest.chatting_room.repository.ChattingRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChattingRoomService {
+
+    private final ChattingRoomRepository chattingRoomRepository;
+
+    public ChattingRoomResponseDto createNewChattingRoomWithName(ChattingRoomRequestDto requestDto) {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        ChattingRoom chattingRoomToSave = ChattingRoom.builder()
+                .chattingRoomName(requestDto.getChattingRoomName())
+                .createdAt(currentDateTime)
+                .lastChattedAt(currentDateTime)
+                .build();
+        ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoomToSave);
+        return toDto(savedChattingRoom);
+    }
+
+    public ChattingRoomResponseDto updateChattingRoomNameById(Long id, ChattingRoomRequestDto requestDto) {
+        ChattingRoom chattingRoomToUpdate = chattingRoomRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+        chattingRoomToUpdate = ChattingRoom.builder()
+                .chattingRoomId(chattingRoomToUpdate.getChattingRoomId())
+                .chattingRoomName(requestDto.getChattingRoomName())
+                .createdAt(chattingRoomToUpdate.getCreatedAt())
+                .lastChattedAt(chattingRoomToUpdate.getLastChattedAt())
+                .build();
+        ChattingRoom updatedChattingRoom = chattingRoomRepository.save(chattingRoomToUpdate);
+        return toDto(updatedChattingRoom);
+    }
+
+    public void deleteChattingRoomById(Long id) {
+        if (!chattingRoomRepository.existsById(id)) {
+            throw new IllegalArgumentException("채팅방이 존재하지 않습니다.");
+        }
+        chattingRoomRepository.deleteById(id);
+    }
+
+    private ChattingRoomResponseDto toDto(ChattingRoom room) {
+        return ChattingRoomResponseDto.builder()
+                .chattingRoomId(room.getChattingRoomId())
+                .chattingRoomName(room.getChattingRoomName())
+                .createdAt(room.getCreatedAt())
+                .lastChattedAt(room.getLastChattedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/virtukch/nest/chatting_room/service/ChattingRoomService.java
+++ b/src/main/java/com/virtukch/nest/chatting_room/service/ChattingRoomService.java
@@ -4,10 +4,10 @@ import com.virtukch.nest.chatting_room.dto.ChattingRoomRequestDto;
 import com.virtukch.nest.chatting_room.dto.ChattingRoomResponseDto;
 import com.virtukch.nest.chatting_room.model.ChattingRoom;
 import com.virtukch.nest.chatting_room.repository.ChattingRoomRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,30 +15,33 @@ public class ChattingRoomService {
 
     private final ChattingRoomRepository chattingRoomRepository;
 
-    public ChattingRoomResponseDto createNewChattingRoomWithName(ChattingRoomRequestDto requestDto) {
+    public ChattingRoomResponseDto createNewChattingRoomWithName(
+        ChattingRoomRequestDto requestDto) {
         LocalDateTime currentDateTime = LocalDateTime.now();
         ChattingRoom chattingRoomToSave = ChattingRoom.builder()
-                .chattingRoomName(requestDto.getChattingRoomName())
-                .createdAt(currentDateTime)
-                .lastChattedAt(currentDateTime)
-                .build();
+            .chattingRoomName(requestDto.getChattingRoomName())
+            .createdAt(currentDateTime)
+            .lastChattedAt(currentDateTime)
+            .build();
         ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoomToSave);
         return toDto(savedChattingRoom);
     }
 
-    public ChattingRoomResponseDto updateChattingRoomNameById(Long id, ChattingRoomRequestDto requestDto) {
+    public ChattingRoomResponseDto updateChattingRoomNameById(Long id,
+        ChattingRoomRequestDto requestDto) {
         ChattingRoom chattingRoomToUpdate = chattingRoomRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
         chattingRoomToUpdate = ChattingRoom.builder()
-                .chattingRoomId(chattingRoomToUpdate.getChattingRoomId())
-                .chattingRoomName(requestDto.getChattingRoomName())
-                .createdAt(chattingRoomToUpdate.getCreatedAt())
-                .lastChattedAt(chattingRoomToUpdate.getLastChattedAt())
-                .build();
+            .chattingRoomId(chattingRoomToUpdate.getChattingRoomId())
+            .chattingRoomName(requestDto.getChattingRoomName())
+            .createdAt(chattingRoomToUpdate.getCreatedAt())
+            .lastChattedAt(chattingRoomToUpdate.getLastChattedAt())
+            .build();
         ChattingRoom updatedChattingRoom = chattingRoomRepository.save(chattingRoomToUpdate);
         return toDto(updatedChattingRoom);
     }
 
+    @Transactional
     public void deleteChattingRoomById(Long id) {
         if (!chattingRoomRepository.existsById(id)) {
             throw new IllegalArgumentException("채팅방이 존재하지 않습니다.");
@@ -48,10 +51,10 @@ public class ChattingRoomService {
 
     private ChattingRoomResponseDto toDto(ChattingRoom room) {
         return ChattingRoomResponseDto.builder()
-                .chattingRoomId(room.getChattingRoomId())
-                .chattingRoomName(room.getChattingRoomName())
-                .createdAt(room.getCreatedAt())
-                .lastChattedAt(room.getLastChattedAt())
-                .build();
+            .chattingRoomId(room.getChattingRoomId())
+            .chattingRoomName(room.getChattingRoomName())
+            .createdAt(room.getCreatedAt())
+            .lastChattedAt(room.getLastChattedAt())
+            .build();
     }
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/controller/ChattingRoomMemberController.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/controller/ChattingRoomMemberController.java
@@ -1,5 +1,6 @@
 package com.virtukch.nest.chatting_room_member.controller;
 
+import com.virtukch.nest.auth.security.CustomUserDetails;
 import com.virtukch.nest.chatting_room_member.dto.ChattingRoomMemberRequestDto;
 import com.virtukch.nest.chatting_room_member.service.ChattingRoomMemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,9 +33,11 @@ public class ChattingRoomMemberController {
         }
     )
     public ResponseEntity<Void> registerChattingRoomMember(
+        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto,
         @Parameter(hidden = true)
-        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRequestDto) {
-        chattingRoomMemberService.registerChattingRoomMember(chattingRoomMemberRequestDto);
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        chattingRoomMemberService.registerChattingRoomMember(
+            chattingRoomMemberRegisterOrRemoveRequestDto);
         return ResponseEntity.ok().build();
     }
 
@@ -47,9 +51,11 @@ public class ChattingRoomMemberController {
         }
     )
     public ResponseEntity<Void> removeChattingRoomMember(
+        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto,
         @Parameter(hidden = true)
-        @RequestBody ChattingRoomMemberRequestDto dto) {
-        chattingRoomMemberService.removeChattingRoomMember(dto);
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        chattingRoomMemberService.removeChattingRoomMember(
+            chattingRoomMemberRegisterOrRemoveRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/controller/ChattingRoomMemberController.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/controller/ChattingRoomMemberController.java
@@ -1,0 +1,55 @@
+package com.virtukch.nest.chatting_room_member.controller;
+
+import com.virtukch.nest.chatting_room_member.dto.ChattingRoomMemberRequestDto;
+import com.virtukch.nest.chatting_room_member.service.ChattingRoomMemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chatting-room-member")
+@RequiredArgsConstructor
+public class ChattingRoomMemberController {
+
+    private final ChattingRoomMemberService chattingRoomMemberService;
+
+    @PostMapping
+    @Operation(
+        summary = "채팅방 입장",
+        description = "사용자가 채팅방에 입장합니다.",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {
+            @ApiResponse(responseCode = "200", description = "입장 성공")
+        }
+    )
+    public ResponseEntity<Void> registerChattingRoomMember(
+        @Parameter(hidden = true)
+        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRequestDto) {
+        chattingRoomMemberService.registerChattingRoomMember(chattingRoomMemberRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    @Operation(
+        summary = "채팅방 퇴장",
+        description = "사용자가 채팅방에서 퇴장합니다.",
+        security = @SecurityRequirement(name = "bearerAuth"),
+        responses = {
+            @ApiResponse(responseCode = "200", description = "퇴장 성공")
+        }
+    )
+    public ResponseEntity<Void> removeChattingRoomMember(
+        @Parameter(hidden = true)
+        @RequestBody ChattingRoomMemberRequestDto dto) {
+        chattingRoomMemberService.removeChattingRoomMember(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/virtukch/nest/chatting_room_member/controller/ChattingRoomMemberController.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/controller/ChattingRoomMemberController.java
@@ -33,11 +33,11 @@ public class ChattingRoomMemberController {
         }
     )
     public ResponseEntity<Void> registerChattingRoomMember(
-        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto,
+        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRequestDto,
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         chattingRoomMemberService.registerChattingRoomMember(
-            chattingRoomMemberRegisterOrRemoveRequestDto);
+            chattingRoomMemberRequestDto);
         return ResponseEntity.ok().build();
     }
 
@@ -51,11 +51,11 @@ public class ChattingRoomMemberController {
         }
     )
     public ResponseEntity<Void> removeChattingRoomMember(
-        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto,
+        @RequestBody ChattingRoomMemberRequestDto chattingRoomMemberRequestDto,
         @Parameter(hidden = true)
         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         chattingRoomMemberService.removeChattingRoomMember(
-            chattingRoomMemberRegisterOrRemoveRequestDto);
+            chattingRoomMemberRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/dto/ChattingRoomMemberRequestDto.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/dto/ChattingRoomMemberRequestDto.java
@@ -1,0 +1,15 @@
+package com.virtukch.nest.chatting_room_member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChattingRoomMemberRequestDto {
+    private Long chattingRoomId;
+    private Long memberId;
+}

--- a/src/main/java/com/virtukch/nest/chatting_room_member/dto/ChattingRoomMemberResponseDto.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/dto/ChattingRoomMemberResponseDto.java
@@ -1,0 +1,16 @@
+package com.virtukch.nest.chatting_room_member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChattingRoomMemberResponseDto {
+    private Long chattingRoomMemberId;
+    private Long chattingRoomId;
+    private Long memberId;
+}

--- a/src/main/java/com/virtukch/nest/chatting_room_member/model/ChattingRoomMember.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/model/ChattingRoomMember.java
@@ -5,11 +5,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChattingRoomMember {
@@ -17,8 +19,6 @@ public class ChattingRoomMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long chattingRoomMemberId;
-
     private Long chattingRoomId;
-
     private Long memberId;
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/model/ChattingRoomMember.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/model/ChattingRoomMember.java
@@ -1,0 +1,24 @@
+package com.virtukch.nest.chatting_room_member.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChattingRoomMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chattingRoomMemberId;
+
+    private Long chattingRoomId;
+
+    private Long memberId;
+}

--- a/src/main/java/com/virtukch/nest/chatting_room_member/repository/ChattingRoomMemberRepository.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/repository/ChattingRoomMemberRepository.java
@@ -1,0 +1,10 @@
+package com.virtukch.nest.chatting_room_member.repository;
+
+import com.virtukch.nest.chatting_room_member.model.ChattingRoomMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChattingRoomMemberRepository extends JpaRepository<ChattingRoomMember, Long> {
+    void deleteByChattingRoomIdAndMemberId(Long chattingRoomId, Long memberId);
+}

--- a/src/main/java/com/virtukch/nest/chatting_room_member/repository/ChattingRoomMemberRepository.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/repository/ChattingRoomMemberRepository.java
@@ -6,5 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChattingRoomMemberRepository extends JpaRepository<ChattingRoomMember, Long> {
+
     void deleteByChattingRoomIdAndMemberId(Long chattingRoomId, Long memberId);
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/service/ChattingRoomMemberService.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/service/ChattingRoomMemberService.java
@@ -13,18 +13,18 @@ public class ChattingRoomMemberService {
     private final ChattingRoomMemberRepository chattingRoomMemberRepository;
 
     public void registerChattingRoomMember(
-        ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto) {
+        ChattingRoomMemberRequestDto chattingRoomMemberRequestDto) {
         ChattingRoomMember chattingRoomMember = ChattingRoomMember.builder()
-            .chattingRoomId(chattingRoomMemberRegisterOrRemoveRequestDto.getChattingRoomId())
-            .memberId(chattingRoomMemberRegisterOrRemoveRequestDto.getMemberId())
+            .chattingRoomId(chattingRoomMemberRequestDto.getChattingRoomId())
+            .memberId(chattingRoomMemberRequestDto.getMemberId())
             .build();
         chattingRoomMemberRepository.save(chattingRoomMember);
     }
 
     public void removeChattingRoomMember(
-        ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto) {
+        ChattingRoomMemberRequestDto chattingRoomMemberRequestDto) {
         chattingRoomMemberRepository.deleteByChattingRoomIdAndMemberId(
-            chattingRoomMemberRegisterOrRemoveRequestDto.getChattingRoomId(),
-            chattingRoomMemberRegisterOrRemoveRequestDto.getMemberId());
+            chattingRoomMemberRequestDto.getChattingRoomId(),
+            chattingRoomMemberRequestDto.getMemberId());
     }
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/service/ChattingRoomMemberService.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/service/ChattingRoomMemberService.java
@@ -5,7 +5,6 @@ import com.virtukch.nest.chatting_room_member.model.ChattingRoomMember;
 import com.virtukch.nest.chatting_room_member.repository.ChattingRoomMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Service
 @RequiredArgsConstructor
@@ -13,15 +12,19 @@ public class ChattingRoomMemberService {
 
     private final ChattingRoomMemberRepository chattingRoomMemberRepository;
 
-    public void registerChattingRoomMember(ChattingRoomMemberRequestDto chattingRoomMemberRequestDto) {
+    public void registerChattingRoomMember(
+        ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto) {
         ChattingRoomMember chattingRoomMember = ChattingRoomMember.builder()
-            .chattingRoomId(chattingRoomMemberRequestDto.getChattingRoomId())
-            .memberId(chattingRoomMemberRequestDto.getMemberId())
+            .chattingRoomId(chattingRoomMemberRegisterOrRemoveRequestDto.getChattingRoomId())
+            .memberId(chattingRoomMemberRegisterOrRemoveRequestDto.getMemberId())
             .build();
         chattingRoomMemberRepository.save(chattingRoomMember);
     }
 
-    public void removeChattingRoomMember(ChattingRoomMemberRequestDto dto) {
-        chattingRoomMemberRepository.deleteByChattingRoomIdAndMemberId(dto.getChattingRoomId(), dto.getMemberId());
+    public void removeChattingRoomMember(
+        ChattingRoomMemberRequestDto chattingRoomMemberRegisterOrRemoveRequestDto) {
+        chattingRoomMemberRepository.deleteByChattingRoomIdAndMemberId(
+            chattingRoomMemberRegisterOrRemoveRequestDto.getChattingRoomId(),
+            chattingRoomMemberRegisterOrRemoveRequestDto.getMemberId());
     }
 }

--- a/src/main/java/com/virtukch/nest/chatting_room_member/service/ChattingRoomMemberService.java
+++ b/src/main/java/com/virtukch/nest/chatting_room_member/service/ChattingRoomMemberService.java
@@ -1,0 +1,27 @@
+package com.virtukch.nest.chatting_room_member.service;
+
+import com.virtukch.nest.chatting_room_member.dto.ChattingRoomMemberRequestDto;
+import com.virtukch.nest.chatting_room_member.model.ChattingRoomMember;
+import com.virtukch.nest.chatting_room_member.repository.ChattingRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Service
+@RequiredArgsConstructor
+public class ChattingRoomMemberService {
+
+    private final ChattingRoomMemberRepository chattingRoomMemberRepository;
+
+    public void registerChattingRoomMember(ChattingRoomMemberRequestDto chattingRoomMemberRequestDto) {
+        ChattingRoomMember chattingRoomMember = ChattingRoomMember.builder()
+            .chattingRoomId(chattingRoomMemberRequestDto.getChattingRoomId())
+            .memberId(chattingRoomMemberRequestDto.getMemberId())
+            .build();
+        chattingRoomMemberRepository.save(chattingRoomMember);
+    }
+
+    public void removeChattingRoomMember(ChattingRoomMemberRequestDto dto) {
+        chattingRoomMemberRepository.deleteByChattingRoomIdAndMemberId(dto.getChattingRoomId(), dto.getMemberId());
+    }
+}


### PR DESCRIPTION
- ChattingRoomMember 입장/퇴장 API 구현
  - POST /api/v1/chatting-room-member → 채팅방 입장
  - DELETE /api/v1/chatting-room-member → 채팅방 퇴장
  - 인증된 사용자 기준으로 memberId 처리 (AuthenticationPrincipal 기반 주입)
- ChattingRoomMemberService 및 Repository 기능 구현
  - registerChattingRoomMember(): builder 패턴 적용
  - removeChattingRoomMember(): deleteByChattingRoomIdAndMemberId 호출
- Swagger 문서화
  - 각 API summary, description, security 설정 추가
  - @AuthenticationPrincipal은 @Parameter(hidden = true)로 비노출 처리
  - request body는 Swagger UI에서 정상적으로 보이도록 구성
- 기타
  - ChattingRoom 이름 수정 API에서 불필요한 권한 관련 설명 제거

====

- 채팅방 접근 권한 체크는 현재 미적용 (모든 인증된 사용자에게 열려 있음)
- 이후 memberId 기반 중복 입장 방지 및 입장 시각 저장 기능 확장 필요