### PR TITLE
Feature/ji hyuk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,208 @@
+# NEST 백엔드 (Spring Boot)
+
+NEST는 캠퍼스/커뮤니티용 프로젝트 모집 및 콘텐츠 플랫폼의 Spring Boot 백엔드입니다. JWT 인증, 회원 프로필, 프로젝트 모집글(이미지 포함/미포함), 프로젝트 지원/멤버십 관리, 일반 게시글/댓글/리액션, 태그/관심/기술스택/학과, 팔로우, 공지, 간단한 채팅방 등을 제공합니다. Swagger UI로 API를 탐색할 수 있습니다.
+
+**주요 특징**
+- JWT 기반 인증/인가, 토큰 재발급, 이메일 기반 비밀번호 재설정
+- 프로젝트 모집글: JSON(v1) + 이미지 포함 Multipart(v2)
+- 프로젝트 지원서/멤버십 역할 관리
+- 게시글/댓글/리액션/공지
+- 태그, 관심사, 기술스택, 학과 관리
+- 프로필 이미지 업로드 및 정적 파일 제공
+- Swagger UI, 도메인별 예외 처리 일원화
+
+**기술 스택**
+- Java 17, Spring Boot 3.4.x
+- Spring Web, Spring Security, Spring Data JPA
+- MySQL 8.x
+- JJWT 0.11.x
+- Springdoc OpenAPI (Swagger UI)
+- Gradle
+
+**포트/접속 경로**
+- 서버 포트: `6030`
+- Swagger UI: `http://localhost:6030/swagger-ui.html`
+- OpenAPI JSON: `http://localhost:6030/v3/api-docs`
+- 정적 이미지: `http://localhost:6030/uploaded-images/...`
+
+## 로컬 실행
+
+사전 준비
+- JDK 17+
+- MySQL 8+ (로컬 DB `nest_db` 권장)
+- Gradle Wrapper 포함
+
+DB 설정
+- `src/main/resources/application.yaml`의 `spring.datasource.*` 값을 환경에 맞게 수정합니다.
+- 기본값(레포 기준):
+  - URL: `jdbc:mysql://localhost:3306/nest_db`
+  - Username: `nest`
+  - Password: `nest`
+
+애플리케이션 설정
+- 파일: `src/main/resources/application.yaml`
+- 주요 키:
+  - `server.port`: 기본 `6030`
+  - `spring.datasource.*`: MySQL 연결 정보
+  - `jwt.secret`, `jwt.access-token-expiration`, `jwt.refresh-token-expiration`
+  - `spring.mail.*`: 이메일 전송 설정(비밀번호 재설정 등)
+
+실행
+- `./gradlew bootRun`
+- 브라우저: `http://localhost:6030`
+
+Jar 빌드
+- `./gradlew bootJar`
+- 산출물: `build/libs/*.jar`
+
+## Docker 실행
+
+- 스크립트 실행: `./docker-build.sh`
+  - 포트 `6030` 바인딩, `./uploaded-images`를 컨테이너 `/app/uploaded-images`로 볼륨 마운트(이미지 영속화)
+- 내부 동작
+  - `bootJar` → jar 빌드
+  - `docker build` → 이미지 태깅: `nest-be-spring-boot-6030-image`
+  - `docker run -p 6030:6030 -v $(pwd)/uploaded-images:/app/uploaded-images`
+
+## 인증
+
+- 엔드포인트: `POST /api/v1/auth/signup`, `POST /api/v1/auth/login`, `POST /api/v1/auth/refresh`
+- 요청 시 헤더: `Authorization: Bearer {access_token}`
+- 토큰 간단 검증: `GET /api/v1/auth/me` (토큰에서 memberId 반환)
+
+비밀번호 재설정
+- `POST /api/v1/auth/password-reset-link-request`
+- `POST /api/v1/auth/password-reset`
+
+## 프로젝트 모듈
+
+컨트롤러
+- v1(JSON): `src/main/java/com/virtukch/nest/project/controller/ProjectController.java`
+- v2(이미지 포함 Multipart): `src/main/java/com/virtukch/nest/project/controller/ProjectV2Controller.java`
+
+주요 엔드포인트
+- 생성(JSON): `POST /api/v1/projects/new`
+  - Body: `ProjectRequestDto`
+    - `projectTitle`(필수), `projectDescription`, `isRecruiting`,
+      `tags: string[]`,
+      `partCounts: { FRONTEND|BACKEND|DESIGNER|PLANNER|DEVOPS|FULLSTACK|ANDROID|IOS: number }`,
+      `creatorPart`, `creatorRole`(기본 `LEADER`), `membersToRemove`
+- 생성(Multipart 이미지 포함): `POST /api/v2/projects`
+  - Form-data: `ProjectWithImagesRequestDto`
+    - v1과 동일한 텍스트 필드 + `images: file[]`
+- 수정 v1(JSON): `PATCH /api/v1/projects/{projectId}`
+- 수정 v2(Multipart): `PATCH /api/v2/projects/{projectId}`
+- 삭제: `DELETE /api/v1/projects/{projectId}`
+- 상세: `GET /api/v1/projects/{projectId}`
+- 목록: `GET /api/v1/projects` (공개)
+- 검색: `GET /api/v1/projects/search`
+- 모집 파트 enum: `GET /api/v1/projects/members` (허용 파트 문자열 목록)
+
+주의
+- 생성/수정/삭제는 유효한 JWT가 필요합니다(없거나 만료/위조 시 401).
+- 작성자가 아닌 경우 수정/삭제 시 403 반환될 수 있습니다.
+
+## 게시글/댓글
+
+- 게시글 v1: `src/main/java/com/virtukch/nest/post/controller/PostController.java`
+- 게시글 v2(이미지): `src/main/java/com/virtukch/nest/post/controller/PostV2Controller.java`
+- 댓글: `src/main/java/com/virtukch/nest/comment/controller/CommentController.java`
+- 공개 조회 허용, 쓰기 작업은 JWT 필요.
+
+## 회원
+
+- 컨트롤러: `src/main/java/com/virtukch/nest/member/controller/MemberController.java`
+- 프로필 조회: `GET /api/v1/members/{memberId}`
+- 내 정보: `GET /api/v1/members/me`
+- 정보 수정: `PATCH /api/v1/members/me`
+- 비밀번호 변경: `PATCH /api/v1/members/me/password`
+- 비밀번호 확인: `POST /api/v1/members/check-password`
+- 프로필 이미지 업로드: `POST /api/v1/members/me/image` (multipart, key=`file`)
+
+## 태그/관심사/기술스택/학과
+
+- 태그: `GET /api/v1/tags/**`, 즐겨찾기 `/api/v1/tag-favorites`
+- 관심사: `GET /api/v1/interests`
+- 기술스택: `GET /api/v1/tech-stacks`
+- 학과: `GET /api/v1/departments`
+
+## 프로젝트 지원/멤버십
+
+- 지원 컨트롤러: `src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java`
+- 역할/enum: `src/main/java/com/virtukch/nest/project_member/model/ProjectMember.java`
+- 최대 인원/역할 제약, 작성자 전용 승인 등 비즈니스 규칙이 적용됩니다(권한 위반 시 403).
+
+## 보안
+
+- 설정: `src/main/java/com/virtukch/nest/auth/security/SecurityConfig.java`
+- JWT 필터: `JwtAuthenticationFilter` (헤더 `Authorization: Bearer {token}`)
+- 공개 엔드포인트(요약):
+  - `/api/v1/auth/**`, `/api/v1/tech-stacks`, `/api/v1/interests`, `/api/v1/departments`, `/api/v1/tags/**`,
+    `/api/v1/posts/search`, `/api/v1/notices/**`, `/api/v1/projects`, `/api/v1/projects/search`,
+    GET: `/api/v1/posts`, `/api/v2/posts`, `/uploaded-images/**`, `/api/v1/projects`, `/api/v2/projects`
+- 그 외 모든 엔드포인트는 인증 필요.
+
+## 정적 이미지
+
+- 레포 루트의 `uploaded-images/`에 저장되고 `/uploaded-images/**`로 서빙됩니다.
+- Docker 실행 시 볼륨 마운트로 컨테이너 재시작 후에도 유지됩니다.
+
+## 에러 처리
+
+- 도메인별 `@RestControllerAdvice`로 일관 응답:
+  - 400: 유효성/잘못된 입력
+  - 401: 비인증(토큰 문제)
+  - 403: 권한 없음(작성자 아님 등)
+  - 404: 리소스 없음
+
+## Postman 빠른 시작
+
+1) 회원가입/로그인
+- `POST /api/v1/auth/signup` → 계정 생성
+- `POST /api/v1/auth/login` → `accessToken` 수신
+
+2) 프로젝트 생성(JSON)
+- `POST /api/v1/projects/new`
+- 헤더: `Authorization: Bearer {access_token}`, `Content-Type: application/json`
+- 예시 바디:
+```
+{
+  "projectTitle": "Team NEST",
+  "projectDescription": "커뮤니티 앱 개발",
+  "isRecruiting": true,
+  "tags": ["SPRING", "REACT"],
+  "partCounts": {"BACKEND": 2, "FRONTEND": 2},
+  "creatorPart": "BACKEND"
+}
+```
+
+3) 이미지 포함 생성(Multipart)
+- `POST /api/v2/projects`
+- 헤더: `Authorization: Bearer {access_token}`
+- Body: `form-data`
+  - 텍스트: `projectTitle`, `projectDescription`, `isRecruiting`, `creatorPart`, `tags`(여러 번 추가 가능), `partCounts[BACKEND]`와 같이 key에 대괄호 문법 사용 가능
+  - 파일: `images` (복수 업로드 가능)
+
+4) 조회
+- `GET /api/v1/projects` (공개)
+- `GET /api/v1/projects/{id}`
+
+문제 해결
+- 401 Unauthorized: 토큰 누락/만료/서명 오류 → 로그인 후 `Authorization: Bearer ...` 재전송
+- 403 Forbidden: 인증은 되었으나 권한 부족(타인 리소스 수정 등) 또는 잘못된 경로 → 생성은 반드시 `/api/v1/projects/new` 또는 `/api/v2/projects` 사용
+
+## 프로젝트 구조
+
+- `src/main/java/com/virtukch/nest/**`: 도메인 패키지(auth, member, project, post, comment, tag, tech_stack, interest, notice, follow, chatting_room 등)
+- `src/main/resources/application.yaml`: DB/JWT/메일/포트 설정
+- `uploaded-images/`: 이미지 저장 디렉터리(런타임)
+- `Dockerfile`, `docker-build.sh`: 컨테이너화 스크립트
+- `System_Architecture.drawio`: 아키텍처 다이어그램 원본
+
+## 보안 주의
+
+- `application.yaml`의 메일 계정/비밀번호, JWT 시크릿 등 민감 정보는 운영 환경에서 환경변수 또는 외부 설정으로 분리하세요(예: Docker/CI 환경 변수, Spring Config Server, KMS 등).
+
+## 라이선스
+
+명시된 라이선스가 없습니다. 외부 배포/재배포 전 저장소 소유자에게 문의하세요.

--- a/docs/Swagger_프론트엔드_가이드.md
+++ b/docs/Swagger_프론트엔드_가이드.md
@@ -1,0 +1,93 @@
+# Swagger UI 사용 가이드 (Frontend 전용)
+
+## 접속
+- Swagger UI: `http://localhost:6030/swagger-ui.html`
+- OpenAPI JSON: `http://localhost:6030/v3/api-docs`
+
+## 공통 규칙
+- 인증 필요 API는 `Authorize` 버튼으로 Bearer 토큰을 입력한 뒤 테스트하세요.
+- Content-Type 주의:
+  - JSON: `application/json`
+  - Multipart: `multipart/form-data`
+  - Form-urlencoded: `application/x-www-form-urlencoded`
+
+## 프로젝트 모집 API 요약
+
+- 생성(v1 JSON): `POST /api/v1/projects/new`
+- 생성(v2 multipart): `POST /api/v2/projects`
+- 생성/수정(v3 payload+images): `POST|PATCH /api/v3/projects[/{id}]`
+  - v3에서는 form-data에 `payload`(JSON) + `images`(File[])로 전송
+- 수정(v1 JSON): `PATCH /api/v1/projects/{id}`
+- 수정(v2 multipart): `PATCH /api/v2/projects/{id}`
+- 목록: `GET /api/v1/projects`
+- 상세: `GET /api/v1/projects/{id}`
+- 검색: `GET /api/v1/projects/search`
+
+### v3 payload 스키마
+- 타입: `ProjectUpsertRequest`
+- 필드:
+  - `projectTitle`: string (필수)
+  - `projectDescription`: string (빈 문자열이면 삭제)
+  - `isRecruiting`: boolean (null이면 미수정)
+  - `tags`: string[] (null이면 미수정, []이면 전체 제거)
+  - `slots`: `{ part: enum(BACKEND|FRONTEND|PM|DESIGN|AI|ETC), count: number }[]`
+  - `creatorPart`: enum (슬롯에 포함되어야 함)
+  - `partCounts`: map (하위호환)
+
+### PATCH 규약(응답 일관성)
+- null: 미수정
+- description == "": 삭제(null)
+- tags null: 미수정, `[]`: 전체 제거
+- v2/v3 이미지: 미포함 → 유지, 포함 → 전체 교체
+
+## 프로젝트 지원/관리 API 요약
+
+- 지원: `POST /api/v1/projects/{projectId}/apply`
+  - JSON 바디: `{ "part": "BACKEND" }`
+  - 또는 form-urlencoded: `part=BACKEND`
+- 지원자 목록(작성자): `GET /api/v1/projects/{projectId}/applications`
+- 수락/거절(작성자): `POST .../accept`, `POST .../reject`
+- 내 지원서 목록: `GET /api/v1/projects/applications/me`
+- 지원 취소(지원자): `POST /api/v1/projects/{projectId}/applications/{applicationId}/cancel`
+
+### 지원 제약
+- 모집 종료(isRecruiting=false) → 불가
+- 이미 멤버 → 불가
+- 파트 정원 가득 참 → 불가
+- 중복 지원 방지(WAITING/ACCEPTED 존재 시)
+
+## 예시 요청(프론트 참고)
+
+### v3 생성(form-data)
+- key: `payload` (Text)
+```
+{
+  "projectTitle": "NEST 팀원 모집(v3)",
+  "projectDescription": "payload + images",
+  "isRecruiting": true,
+  "tags": ["UNCATEGORIZED"],
+  "slots": [
+    {"part": "BACKEND", "count": 2},
+    {"part": "FRONTEND", "count": 2}
+  ],
+  "creatorPart": "BACKEND"
+}
+```
+- key: `images` (File), 여러 개 첨부 가능
+
+### 지원(JSON)
+```
+POST /api/v1/projects/{projectId}/apply
+{
+  "part": "BACKEND"
+}
+```
+
+### 응답 타입 참고
+- `ProjectResponseDto`: `{ projectId: number, message: string }`
+- `ProjectApplicationResponseDto`: `{ applicationId, memberId, memberName, part, status, appliedAt }`
+
+## 팁
+- Swagger의 “Try it out”로 바로 테스트 가능
+- enum 값은 대소문자 구분 없이 사용 가능하도록 백엔드에서 처리 중이나, UI에서는 상수 대문자 사용을 권장합니다.
+- 파일 업로드는 브라우저 환경에서 `FormData` 사용 권장(`append('payload', JSON.stringify(obj))`, `append('images', file)`).

--- a/docs/프로젝트_모집_DTO_개선_제안.md
+++ b/docs/프로젝트_모집_DTO_개선_제안.md
@@ -1,0 +1,144 @@
+# 프로젝트 모집 DTO/엔드포인트 개선 제안
+
+목표: 프론트엔드가 단순한 JSON/Multipart로 손쉽게 생성/수정 요청을 보낼 수 있도록 입력 스키마와 엔드포인트를 단순화하고, 하위호환을 유지합니다.
+
+## 핵심 제안
+
+- 슬롯(Map) → 리스트(배열) 구조로 단순화
+- Multipart에서는 `payload`(JSON) + `images`(파일) 구조 채택
+- 부분 수정(PATCH) 전용 라우트를 세분화해 복잡한 통합 DTO 의존도 낮춤
+- 하위호환: 기존 `partCounts(Map<Part, Integer>)`도 계속 수용, 서버에서 통합 처리
+
+## 1) 신규 공통 DTO (JSON 페이로드)
+
+- ProjectSlotsDto
+```
+{
+  "part": "BACKEND",   // enum: BACKEND|FRONTEND|PM|DESIGN|AI|ETC (대소문자 무시)
+  "count": 2             // 정원(빈 슬롯 포함)
+}
+```
+
+- ProjectUpsertRequest (v3 제안, v1에도 적용 가능)
+```
+{
+  "projectTitle": "NEST 팀원 모집",
+  "projectDescription": "커뮤니티 앱 백엔드 개발",
+  "isRecruiting": true,
+  "tags": ["UNCATEGORIZED"],
+  "slots": [
+    {"part": "BACKEND", "count": 2},
+    {"part": "FRONTEND", "count": 2},
+    {"part": "PM", "count": 1}
+  ],
+  "creatorPart": "BACKEND"
+}
+```
+
+설명
+- `slots`: 필수(생성 시). 수정 시 null=미수정, []=전체 제거(금지 권고)처럼 해석 가능하나, 안정성을 위해 전용 엔드포인트를 권장(아래 3장).
+- `creatorPart`: 미제공 시 서버가 `slots`의 첫 파트를 자동 배정하도록 기본값 처리 가능.
+- 하위호환: 기존 `partCounts`도 함께 지원. 서버에서 `slots` 우선 → 없으면 `partCounts` 사용.
+
+## 2) Multipart(v2) 개선
+
+- 현재: `@ModelAttribute ProjectWithImagesRequestDto` + `partCounts[KEY]` 형태 → Postman/UI에서 번거로움
+- 개선: `@RequestPart("payload") ProjectUpsertRequest` + `@RequestPart(value="images", required=false) List<MultipartFile>`
+
+form-data 예시
+- key: `payload` (type: Text)
+```
+{
+  "projectTitle": "NEST 팀원 모집(이미지)",
+  "projectDescription": "이미지와 함께",
+  "isRecruiting": true,
+  "tags": ["UNCATEGORIZED"],
+  "slots": [{"part": "BACKEND", "count": 2}, {"part": "FRONTEND", "count": 2}],
+  "creatorPart": "BACKEND"
+}
+```
+- key: `images` (type: File, multiple)
+
+하위호환
+- 기존 `@ModelAttribute` 경로를 유지하고, 신규 `@RequestPart payload` 경로를 추가(v2.1 또는 v3 경로)하여 점진 전환.
+
+## 3) 부분 수정 라우트 세분화 (권장)
+
+복잡한 통합 PATCH 대신 작은 단위로 나눠 프론트 난이도/실수 감소.
+
+- 모집 여부 토글
+  - `PATCH /api/v1/projects/{id}/recruiting`
+  - Body: `{ "isRecruiting": true }`
+
+- 태그 교체
+  - `PATCH /api/v1/projects/{id}/tags`
+  - Body: `{ "tags": ["UNCATEGORIZED", "SPRING"] }`
+
+- 슬롯(정원) 재설정
+  - `PATCH /api/v1/projects/{id}/slots`
+  - Body: `{ "slots": [{"part":"BACKEND","count":3}, ...] }`
+  - 서버 로직: 현재 채워진 인원 수 미만으로는 축소 불가(현행 규칙 유지), 빈 슬롯만 삭제/추가
+
+- 작성자 파트 변경
+  - `PATCH /api/v1/projects/{id}/creator-part`
+  - Body: `{ "creatorPart": "PM" }`
+
+- 텍스트 필드 수정
+  - `PATCH /api/v1/projects/{id}/text`
+  - Body: `{ "projectTitle": "새 제목", "projectDescription": "새 설명" }`
+
+## 4) 서버 수용 로직 (요약)
+
+- DTO 수용 우선순위
+  - `slots` 있으면 사용 → 없으면 `partCounts` 사용
+- Multipart
+  - `payload`(JSON) + `images`(파일 배열)
+- PATCH 규약(기반 코드 반영됨)
+  - `null` 값 → 미수정
+  - `projectDescription == ""` → 삭제(null)
+  - `tags == null` → 미수정, `tags == []` → 전부 제거
+
+## 5) 마이그레이션/하위호환
+
+- v1/v2 기존 엔드포인트 유지
+- v2에 `payload` 지원 추가(v2.1) 또는 신규 v3 경로 제공
+- FE는 점진적으로 `slots`/`payload` 방식으로 전환
+
+## 6) 검증/오류 메시지 UX
+
+- `slots` 비어있음 → 400 + "최소 1개 역할 필요"
+- `creatorPart`가 `slots`에 없음 → 400 + "creatorPart는 slots에 포함되어야 합니다"
+- 알 수 없는 태그 → 400 + 태그 목록 조회 링크 제공(`/api/v1/tags`)
+- enum 대소문자 허용 및 친절한 메시지
+
+## 7) 예시 스니펫 (Postman Raw JSON)
+
+생성(v1)
+```
+POST /api/v1/projects/new
+{
+  "projectTitle": "NEST",
+  "projectDescription": "플랫폼 백엔드",
+  "isRecruiting": true,
+  "tags": ["UNCATEGORIZED"],
+  "slots": [
+    {"part":"BACKEND","count":2},
+    {"part":"FRONTEND","count":2}
+  ],
+  "creatorPart":"BACKEND"
+}
+```
+
+수정(슬롯 재설정)
+```
+PATCH /api/v1/projects/{id}/slots
+{
+  "slots": [
+    {"part":"BACKEND","count":3},
+    {"part":"FRONTEND","count":1}
+  ]
+}
+```
+
+---
+필요 시 위 제안을 기준으로 DTO/컨트롤러 실제 코드 패치까지 진행하겠습니다. 하위호환을 유지하며 신규 필드/엔드포인트를 추가하는 방향이 안전합니다.

--- a/src/main/java/com/virtukch/nest/comment/repository/CommentRepository.java
+++ b/src/main/java/com/virtukch/nest/comment/repository/CommentRepository.java
@@ -40,6 +40,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     void deleteAllByPostId(Long postId);
 
+    void deleteAllByBoardTypeAndPostId(BoardType boardType, Long postId);
+
     Optional<Comment> findById(Long commentId);
 
     boolean existsByParentId(Long parentId);

--- a/src/main/java/com/virtukch/nest/project/controller/ProjectController.java
+++ b/src/main/java/com/virtukch/nest/project/controller/ProjectController.java
@@ -39,8 +39,8 @@ public class ProjectController {
             - `projectDescription`: 프로젝트 상세 설명 (선택, null 값은 빈 문자열로 간주)
             - `tags`: 태그 목록 (선택, 태그 목록에 존재하는 태그만 설정 가능)
             - `parts`: 모집 역할 및 인원 리스트 (필수, Map<String, Integer> 형태)
-                - 예: {"FRONTEND": 2, "BACKEND": 1, "DESIGNER": 1}
-                - 가능한 역할: FRONTEND, BACKEND, DESIGNER, PLANNER, DEVOPS, FULLSTACK, ANDROID, IOS
+                - 예: {"FRONTEND": 2, "BACKEND": 1, "PM": 1}
+                - 가능한 역할(enum): BACKEND, FRONTEND, PM, DESIGN, AI, ETC
 
             ## 제약 조건
             ✔️ 로그인된 사용자만 작성 가능
@@ -63,7 +63,7 @@ public class ProjectController {
         log.info("[모집글 작성 요청] memberId={}", memberId);
         ProjectResponseDto responseDto = projectService.createProject(memberId, requestDTO);
         return ResponseEntity
-                .created(URI.create("/api/projects/" + responseDto.getProjectId()))
+                .created(URI.create("/api/v1/projects/" + responseDto.getProjectId()))
                 .body(responseDto);
     }
 

--- a/src/main/java/com/virtukch/nest/project/controller/ProjectV3Controller.java
+++ b/src/main/java/com/virtukch/nest/project/controller/ProjectV3Controller.java
@@ -1,0 +1,91 @@
+package com.virtukch.nest.project.controller;
+
+import com.virtukch.nest.auth.security.CustomUserDetails;
+import com.virtukch.nest.project.dto.ProjectResponseDto;
+import com.virtukch.nest.project.dto.ProjectUpsertRequest;
+import com.virtukch.nest.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v3/projects")
+@Tag(name = "[프로젝트 모집 게시판 v3] 게시글 API", description = "payload(JSON) + images(multipart) 구조의 간소화된 API")
+public class ProjectV3Controller {
+    private final ProjectService projectService;
+
+    @Operation(
+        summary = "프로젝트 모집글 생성 (payload + images)",
+        description = """
+            multipart/form-data로 JSON `payload`와 파일 배열 `images`를 함께 전송합니다.
+            
+            - payload(JSON): ProjectUpsertRequest 스키마 참고
+            - images(File[]) : 선택, 여러 개 첨부 가능 (전체 교체 기준)
+            - consumes: multipart/form-data
+            
+            예시 (form-data):
+            - payload: {
+                "projectTitle":"NEST 팀원 모집(v3)",
+                "projectDescription":"payload + images",
+                "isRecruiting":true,
+                "tags":["UNCATEGORIZED"],
+                "slots":[{"part":"BACKEND","count":2},{"part":"FRONTEND","count":2}],
+                "creatorPart":"BACKEND"
+              }
+            - images: file1, file2 ...
+            
+            응답: 201 Created + ProjectResponseDto (Location 헤더 포함)
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ProjectResponseDto> createProject(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestPart("payload") ProjectUpsertRequest payload,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+
+        Long memberId = user.getMember().getMemberId();
+        log.info("[모집글 생성 v3 요청] memberId={}", memberId);
+        ProjectResponseDto responseDto = projectService.createProject(memberId, payload, images);
+        return ResponseEntity
+                .created(URI.create("/api/v3/projects/" + responseDto.getProjectId()))
+                .body(responseDto);
+    }
+
+    @Operation(
+        summary = "프로젝트 모집글 수정 (payload + images)",
+        description = """
+            multipart/form-data로 JSON `payload`와 파일 배열 `images`를 함께 전송합니다.
+            
+            - payload(JSON): null 필드는 미수정, 설명 빈 문자열은 삭제
+            - images(File[]): 미포함 시 기존 유지, 포함 시 전체 교체
+            
+            응답: 200 OK + ProjectResponseDto
+            """,
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @PatchMapping(path = "/{projectId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ProjectResponseDto> updateProject(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long projectId,
+            @RequestPart("payload") ProjectUpsertRequest payload,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+
+        Long memberId = user.getMember().getMemberId();
+        log.info("[모집글 수정 v3 요청] projectId={}, memberId={}", projectId, memberId);
+        ProjectResponseDto responseDto = projectService.updateProject(projectId, memberId, payload, images);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/virtukch/nest/project/dto/ProjectSlotDto.java
+++ b/src/main/java/com/virtukch/nest/project/dto/ProjectSlotDto.java
@@ -1,0 +1,17 @@
+package com.virtukch.nest.project.dto;
+
+import com.virtukch.nest.project_member.model.ProjectMember;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "역할별 정원 정보")
+public class ProjectSlotDto {
+    @Schema(description = "역할", example = "BACKEND")
+    private ProjectMember.Part part;
+
+    @Schema(description = "정원(빈 슬롯 포함)", example = "2")
+    private Integer count;
+}

--- a/src/main/java/com/virtukch/nest/project/dto/ProjectUpsertRequest.java
+++ b/src/main/java/com/virtukch/nest/project/dto/ProjectUpsertRequest.java
@@ -1,0 +1,43 @@
+package com.virtukch.nest.project.dto;
+
+import com.virtukch.nest.project_member.model.ProjectMember;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "프로젝트 생성/수정용 JSON 페이로드")
+public class ProjectUpsertRequest {
+    @NotBlank(message = "모집글 제목은 비어 있을 수 없습니다.")
+    @Schema(description = "제목", example = "NEST 팀원 모집")
+    private String projectTitle;
+
+    @Schema(description = "설명(빈 문자열이면 삭제)", example = "커뮤니티 앱 백엔드 개발")
+    private String projectDescription;
+
+    @Schema(description = "모집 중 여부(null이면 미수정)", example = "true")
+    private Boolean isRecruiting;
+
+    @Schema(description = "태그 목록(null이면 미수정, []면 전부 제거)", example = "[\"UNCATEGORIZED\", \"SPRING\"]")
+    private List<String> tags;
+
+    @Schema(description = "역할별 정원 배열 구조")
+    private List<ProjectSlotDto> slots;
+
+    @Schema(description = "하위호환: map 구조도 허용(slots가 없을 때 사용)")
+    private Map<ProjectMember.Part, Integer> partCounts;
+
+    @Schema(description = "작성자 파트(슬롯에 포함되어야 함)", example = "BACKEND")
+    private ProjectMember.Part creatorPart; // 작성자가 들어갈 파트
+
+    @Schema(description = "작성자 역할", example = "LEADER")
+    private ProjectMember.Role creatorRole = ProjectMember.Role.LEADER; // 기본값 LEADER
+
+    @Schema(description = "제거할 멤버 ID 목록(선택)")
+    private List<Long> membersToRemove;
+}

--- a/src/main/java/com/virtukch/nest/project/model/Project.java
+++ b/src/main/java/com/virtukch/nest/project/model/Project.java
@@ -65,22 +65,29 @@ public class Project extends BaseTimeEntity {
 
 
 
-    //프로젝트 업데이트 메서드
+    //프로젝트 업데이트 메서드 (부분 수정 규약)
     public void updateProject(String projectTitle,
                               String projectDescription,
                               Boolean isRecruiting) {
-        if(projectTitle != null && !projectTitle.isBlank()) {
-            this.projectTitle = projectTitle;
-        } else throw new InvalidProjectTitleException();
-
-        if(projectDescription != null && !projectDescription.isBlank()) {
-            this.projectDescription = projectDescription;
+        // 제목: null/빈문자열이면 변경하지 않음, 값이 있으면 변경
+        if (projectTitle != null) {
+            if (!projectTitle.isBlank()) {
+                this.projectTitle = projectTitle;
+            } // 빈 문자열이면 변경하지 않음
         }
 
-        if(isRecruiting) {
-            this.isRecruiting = true;
-        } else {
-            this.isRecruiting = false;
+        // 설명: null이면 변경하지 않음, 빈 문자열이면 삭제, 값이 있으면 변경
+        if (projectDescription != null) {
+            if (projectDescription.isBlank()) {
+                this.projectDescription = null; // 빈 문자열은 삭제 의미
+            } else {
+                this.projectDescription = projectDescription;
+            }
+        }
+
+        // 모집여부: null이면 변경하지 않음, 값이 있으면 해당 값으로 설정
+        if (isRecruiting != null) {
+            this.isRecruiting = isRecruiting;
         }
     }
 

--- a/src/main/java/com/virtukch/nest/project/service/ProjectService.java
+++ b/src/main/java/com/virtukch/nest/project/service/ProjectService.java
@@ -17,6 +17,7 @@ import com.virtukch.nest.project_member.repository.ProjectMemberRepository;
 import com.virtukch.nest.project_tag.model.ProjectTag;
 import com.virtukch.nest.project_tag.repository.ProjectTagRepository;
 import com.virtukch.nest.tag.model.Tag;
+import com.virtukch.nest.tag.model.Category;
 import com.virtukch.nest.tag.repository.TagRepository;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -89,6 +91,32 @@ public class ProjectService {
          }
 
         log.info("[모집글 생성 완료] projectId={}", project.getProjectId());
+        return ProjectDtoConverter.toCreateResponseDto(project);
+    }
+
+    // v3: payload(JSON) + images
+    @Transactional
+    public ProjectResponseDto createProject(Long memberId, ProjectUpsertRequest payload, List<MultipartFile> images) {
+        String title = payload.getProjectTitle();
+        log.info("[모집글 생성(v3) 시작] title={}, memberId={}", title, memberId);
+        Project project = projectRepository.save(Project.createProject(memberId, title, payload.getProjectDescription()));
+
+        saveProjectTags(project, payload.getTags());
+
+        Map<ProjectMember.Part, Integer> partMap = resolvePartCounts(payload.getPartCounts(), payload.getSlots());
+        if (partMap != null && !partMap.isEmpty()) {
+            Member creator = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new RuntimeException("Member not found"));
+            createProjectMembers(project.getProjectId(), creator.getMemberId(),
+                    partMap, payload.getCreatorPart(), payload.getCreatorRole());
+        }
+
+        if (images != null && !images.isEmpty()){
+            List<String> imageUrls = imageService.uploadImages(images, prefix, project.getProjectId());
+            project.updateProject(project.getProjectTitle(), project.getProjectDescription(), project.getIsRecruiting(), imageUrls);
+        }
+
+        log.info("[모집글 생성(v3) 완료] projectId={}", project.getProjectId());
         return ProjectDtoConverter.toCreateResponseDto(project);
     }
 
@@ -168,9 +196,13 @@ public class ProjectService {
             projectMemberRepository.save(creator);
         }
 
-        projectTagRepository.deleteAllByProjectId(projectId);
-
-        saveProjectTags(project, requestDto.getTags());
+        // 태그: null이면 미수정, 빈 배열이면 모두 제거, 값 있으면 재설정
+        if (requestDto.getTags() != null) {
+            projectTagRepository.deleteAllByProjectId(projectId);
+            if (!requestDto.getTags().isEmpty()) {
+                saveProjectTags(project, requestDto.getTags());
+            }
+        }
 
         if (requestDto.getPartCounts() != null && !requestDto.getPartCounts().isEmpty()) {
             updatePartCounts(projectId, requestDto.getPartCounts());
@@ -183,9 +215,14 @@ public class ProjectService {
     public ProjectResponseDto updateProject(Long projectId, Long memberId, ProjectWithImagesRequestDto requestDto){
         Project project = validateProjectOwnershipAndGet(projectId, memberId);
 
-        List<String> imageUrls = imageService.replaceImages(requestDto.getImages(), prefix, projectId, project.getImageUrlList());
-        project.updateProject(project.getProjectTitle(), project.getProjectDescription(),
-                project.getIsRecruiting(), imageUrls);
+        // 이미지: null이면 미수정, 값 있으면 교체
+        List<String> imageUrls = project.getImageUrlList();
+        if (requestDto.getImages() != null) {
+            imageUrls = imageService.replaceImages(requestDto.getImages(), prefix, projectId, project.getImageUrlList());
+        }
+        // 텍스트/모집여부도 요청 값 기반으로 갱신
+        project.updateProject(requestDto.getProjectTitle(), requestDto.getProjectDescription(),
+                requestDto.getIsRecruiting(), imageUrls);
 
         // Remove members if specified in requestDto before updating part counts
         if (requestDto.getMembersToRemove() != null && !requestDto.getMembersToRemove().isEmpty()) {
@@ -201,14 +238,74 @@ public class ProjectService {
             projectMemberRepository.save(creator);
         }
 
-        projectTagRepository.deleteAllByProjectId(project.getProjectId());
-        saveProjectTags(project, requestDto.getTags());
+        // 태그: null이면 미수정, 빈 배열이면 모두 제거, 값 있으면 재설정
+        if (requestDto.getTags() != null) {
+            projectTagRepository.deleteAllByProjectId(project.getProjectId());
+            if (!requestDto.getTags().isEmpty()) {
+                saveProjectTags(project, requestDto.getTags());
+            }
+        }
 
         if (requestDto.getPartCounts() != null && !requestDto.getPartCounts().isEmpty()) {
             updatePartCounts(projectId, requestDto.getPartCounts());
         }
 
         return ProjectDtoConverter.toUpdateResponseDto(project);
+    }
+
+    // v3: payload(JSON) + images
+    @Transactional
+    public ProjectResponseDto updateProject(Long projectId, Long memberId, ProjectUpsertRequest payload, List<MultipartFile> images){
+        Project project = validateProjectOwnershipAndGet(projectId, memberId);
+
+        List<String> imageUrls = project.getImageUrlList();
+        if (images != null) {
+            imageUrls = imageService.replaceImages(images, prefix, projectId, project.getImageUrlList());
+        }
+        project.updateProject(payload.getProjectTitle(), payload.getProjectDescription(),
+                payload.getIsRecruiting(), imageUrls);
+
+        if (payload.getMembersToRemove() != null && !payload.getMembersToRemove().isEmpty()) {
+            removeProjectMembers(projectId, payload.getMembersToRemove());
+        }
+
+        if (payload.getCreatorPart() != null) {
+            ProjectMember.Part newPart = payload.getCreatorPart();
+            ProjectMember creator = projectMemberRepository.findByProjectIdAndMemberId(projectId, memberId)
+                .orElseThrow(CanNotRemoveCreatorException::new);
+            creator.setPart(newPart);
+            projectMemberRepository.save(creator);
+        }
+
+        if (payload.getTags() != null) {
+            projectTagRepository.deleteAllByProjectId(project.getProjectId());
+            if (!payload.getTags().isEmpty()) {
+                saveProjectTags(project, payload.getTags());
+            }
+        }
+
+        Map<ProjectMember.Part, Integer> partMap = resolvePartCounts(payload.getPartCounts(), payload.getSlots());
+        if (partMap != null && !partMap.isEmpty()) {
+            updatePartCounts(projectId, partMap);
+        }
+
+        return ProjectDtoConverter.toUpdateResponseDto(project);
+    }
+
+    private Map<ProjectMember.Part, Integer> resolvePartCounts(Map<ProjectMember.Part, Integer> partCounts, List<ProjectSlotDto> slots) {
+        if (partCounts != null) {
+            return partCounts;
+        }
+        if (slots == null || slots.isEmpty()) {
+            return null;
+        }
+        Map<ProjectMember.Part, Integer> map = new EnumMap<>(ProjectMember.Part.class);
+        for (ProjectSlotDto slot : slots) {
+            if (slot != null && slot.getPart() != null && slot.getCount() != null) {
+                map.put(slot.getPart(), slot.getCount());
+            }
+        }
+        return map;
     }
 
     @Transactional
@@ -280,8 +377,14 @@ public class ProjectService {
     public ProjectResponseDto deleteProject(Long projectId, Long memberId) {
         Project project = validateProjectOwnershipAndGet(projectId, memberId);
 
+        // 태그 제거
         projectTagRepository.deleteAllByProjectId(projectId);
-        commentRepository.deleteAllByPostId(projectId);
+        // 댓글 제거 (프로젝트 게시판 한정)
+        commentRepository.deleteAllByBoardTypeAndPostId(com.virtukch.nest.comment.model.BoardType.PROJECT, projectId);
+        // 프로젝트 멤버/지원서 제거
+        projectMemberRepository.deleteAll(projectMemberRepository.findByProjectId(projectId));
+        projectApplicationRepository.deleteAll(projectApplicationRepository.findByProjectId(projectId));
+        // 프로젝트 삭제
         projectRepository.delete(project);
         return ProjectDtoConverter.toDeleteResponseDto(project);
     }
@@ -302,11 +405,14 @@ public class ProjectService {
 
     @Transactional
     protected void saveProjectTags(Project project, List<String> tagNames) {
-        List<String> tags = (tagNames == null || tagNames.isEmpty())
-                ? List.of("UNCATEGORIZED")
-                : tagNames;
+        // 생성 시: null/빈 배열이면 UNCATEGORIZED 보장 생성 후 적용
+        if (tagNames == null || tagNames.isEmpty()) {
+            Tag tag = tagService.findOrCreateTag(Category.UNCATEGORIZED, "UNCATEGORIZED");
+            projectTagRepository.save(new ProjectTag(project.getProjectId(), tag.getId()));
+            return;
+        }
 
-        tags.stream()
+        tagNames.stream()
                 .map(tagService::findByNameOrThrow)
                 .map(tag -> new ProjectTag(project.getProjectId(), tag.getId()))
                 .forEachOrdered(projectTagRepository::save);

--- a/src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java
+++ b/src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java
@@ -6,6 +6,7 @@ import com.virtukch.nest.project_application.dto.ProjectApplicationResponseDto;
 import com.virtukch.nest.project_application.service.ProjectApplicationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -56,12 +57,24 @@ public class ProjectApplicationController {
             """,
         security = {@SecurityRequirement(name = "bearer-key")}
     )
-    @PostMapping("/{projectId}/apply")
+    @PostMapping(path = "/{projectId}/apply", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ProjectApplicationResponseDto> projectApplicationApply(@AuthenticationPrincipal CustomUserDetails user,
                                       @PathVariable Long projectId,
                                       @RequestBody ProjectApplicationRequestDto requestDto) {
         Long memberId = user.getMember().getMemberId();
         ProjectApplicationResponseDto responseDto = projectApplicationService.applyToProject(projectId, memberId, requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // x-www-form-urlencoded 호환 (Postman에서 form-data 또는 urlencoded로 전송 시)
+    @PostMapping(path = "/{projectId}/apply", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public ResponseEntity<ProjectApplicationResponseDto> projectApplicationApplyForm(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long projectId,
+            @RequestParam("part") com.virtukch.nest.project_member.model.ProjectMember.Part part
+    ) {
+        Long memberId = user.getMember().getMemberId();
+        ProjectApplicationResponseDto responseDto = projectApplicationService.applyToProject(projectId, memberId, part);
         return ResponseEntity.ok(responseDto);
     }
 
@@ -102,9 +115,11 @@ public class ProjectApplicationController {
         security = {@SecurityRequirement(name = "bearer-key")}
     )
     @GetMapping("/{projectId}/applications")
-    public ResponseEntity<List<ProjectApplicationResponseDto>> getProjectApplications(@AuthenticationPrincipal CustomUserDetails user,
+    public ResponseEntity<List<ProjectApplicationResponseDto>> getProjectApplications(
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long projectId) {
-        List<ProjectApplicationResponseDto> applications = projectApplicationService.getApplicationsByProject(projectId);
+        Long requesterId = user.getMember().getMemberId();
+        List<ProjectApplicationResponseDto> applications = projectApplicationService.getApplicationsByProject(projectId, requesterId);
         return ResponseEntity.ok(applications);
     }
 
@@ -201,6 +216,32 @@ public class ProjectApplicationController {
         Long memberId = user.getMember().getMemberId();
         ProjectApplicationResponseDto responseDto = projectApplicationService.rejectApplication(projectId, applicationId, memberId);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(
+        summary = "내 지원서 목록 조회",
+        description = "로그인한 사용자의 모든 프로젝트 지원서를 조회합니다.",
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @GetMapping("/applications/me")
+    public ResponseEntity<List<ProjectApplicationResponseDto>> getMyApplications(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        Long memberId = user.getMember().getMemberId();
+        return ResponseEntity.ok(projectApplicationService.getApplicationsByMember(memberId));
+    }
+
+    @Operation(
+        summary = "지원 취소",
+        description = "지원자가 본인의 PENDING(대기) 상태 지원서를 취소합니다.",
+        security = {@SecurityRequirement(name = "bearer-key")}
+    )
+    @PostMapping("/{projectId}/applications/{applicationId}/cancel")
+    public ResponseEntity<ProjectApplicationResponseDto> cancelApplication(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long projectId,
+            @PathVariable Long applicationId) {
+        Long memberId = user.getMember().getMemberId();
+        return ResponseEntity.ok(projectApplicationService.cancelApplication(projectId, applicationId, memberId));
     }
 
 }

--- a/src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationRequestDto.java
+++ b/src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationRequestDto.java
@@ -1,12 +1,15 @@
 package com.virtukch.nest.project_application.dto;
 
-
 import com.virtukch.nest.project_member.model.ProjectMember;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-
 @Getter
+@Schema(description = "프로젝트 지원 요청 바디(JSON)")
 public class ProjectApplicationRequestDto {
+    @Schema(description = "경로 변수로 전달되므로 무시됩니다.")
     private Long projectId;
+
+    @Schema(description = "지원 파트", example = "BACKEND")
     private ProjectMember.Part part;
 }

--- a/src/main/java/com/virtukch/nest/project_application/service/ProjectApplicationService.java
+++ b/src/main/java/com/virtukch/nest/project_application/service/ProjectApplicationService.java
@@ -37,12 +37,27 @@ public class ProjectApplicationService extends BaseTimeEntity {
 
     @Transactional
     public ProjectApplicationResponseDto applyToProject(Long projectId, Long memberId, ProjectApplicationRequestDto requestDto) {
+        return applyToProject(projectId, memberId, requestDto.getPart());
+    }
+
+    @Transactional
+    public ProjectApplicationResponseDto applyToProject(Long projectId, Long memberId, com.virtukch.nest.project_member.model.ProjectMember.Part part) {
 
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectNotFoundException(projectId));
 
         if (project.getMemberId().equals(memberId)) {
             throw new ProjectOwnerCannotApplyException(); // 또는 IllegalStateException
+        }
+
+        // 모집 중이 아닌 경우 지원 불가
+        if (Boolean.FALSE.equals(project.getIsRecruiting())) {
+            throw new ProjectFullException("현재 모집 중이 아닙니다.");
+        }
+
+        // 이미 프로젝트 멤버인 경우 지원 불가
+        if (projectMemberRepository.findByProjectIdAndMemberId(projectId, memberId).isPresent()) {
+            throw new DuplicateApplicationException();
         }
 
         projectRepository.findById(projectId)
@@ -56,10 +71,17 @@ public class ProjectApplicationService extends BaseTimeEntity {
             throw new DuplicateApplicationException();
         }
 
+        // 파트 정원 초과 시 즉시 차단 (빈 슬롯/정원 확인)
+        long maxCount = projectMemberRepository.countByProjectIdAndPart(projectId, part);
+        long approvedCount = projectMemberRepository.countByProjectIdAndPartAndMemberIdIsNotNull(projectId, part);
+        if (approvedCount >= maxCount) {
+            throw new ProjectFullException(part + " 파트의 모집 인원이 가득 찼습니다.");
+        }
+
         ProjectApplication application = ProjectApplication.builder()
                 .projectId(projectId)
                 .memberId(memberId)
-                .part(requestDto.getPart())
+                .part(part)
                 .status(ProjectApplication.ApplicationStatus.WAITING)
                 .appliedAt(LocalDateTime.now())
                 .build();
@@ -72,7 +94,13 @@ public class ProjectApplicationService extends BaseTimeEntity {
     }
 
     @Transactional
-    public List<ProjectApplicationResponseDto> getApplicationsByProject(Long projectId) {
+    public List<ProjectApplicationResponseDto> getApplicationsByProject(Long projectId, Long requesterId) {
+        // 프로젝트 소유자만 조회 가능
+        Long writerId = projectRepository.searchWriterIdByProjectId(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException(projectId));
+        if (!writerId.equals(requesterId)) {
+            throw new NotProjectOwnerException();
+        }
 
         List<ProjectApplication> applications = projectApplicationRepository.findByProjectId(projectId);
 
@@ -155,6 +183,34 @@ public class ProjectApplicationService extends BaseTimeEntity {
         application.setStatus(ProjectApplication.ApplicationStatus.REJECTED);
         projectApplicationRepository.save(application);
 
+        Member member = memberRepository.findById(application.getMemberId()).orElse(null);
+        return ProjectApplicationDtoConverter.toResponseDto(application, member != null ? member.getMemberName() : "알 수 없음");
+    }
+
+    @Transactional
+    public List<ProjectApplicationResponseDto> getApplicationsByMember(Long memberId) {
+        List<ProjectApplication> applications = projectApplicationRepository.findByMemberId(memberId);
+        return applications.stream().map(app -> {
+            Member member = memberRepository.findById(app.getMemberId()).orElse(null);
+            return ProjectApplicationDtoConverter.toResponseDto(app, member != null ? member.getMemberName() : "알 수 없음");
+        }).toList();
+    }
+
+    @Transactional
+    public ProjectApplicationResponseDto cancelApplication(Long projectId, Long applicationId, Long requesterId) {
+        ProjectApplication application = projectApplicationRepository.findById(applicationId)
+                .orElseThrow(ApplicationNotFoundException::new);
+        if (!application.getProjectId().equals(projectId)) {
+            throw new ApplicationNotFoundException();
+        }
+        if (!application.getMemberId().equals(requesterId)) {
+            throw new NotProjectOwnerException(); // 본인만 취소 가능 (권한 예외 재사용)
+        }
+        if (application.getStatus() != ProjectApplication.ApplicationStatus.WAITING) {
+            throw new AlreadyProcessedApplicationException();
+        }
+        application.setStatus(ProjectApplication.ApplicationStatus.CANCELED);
+        projectApplicationRepository.save(application);
         Member member = memberRepository.findById(application.getMemberId()).orElse(null);
         return ProjectApplicationDtoConverter.toResponseDto(application, member != null ? member.getMemberName() : "알 수 없음");
     }

--- a/src/main/java/com/virtukch/nest/project_member/controller/ProjectMemberController.java
+++ b/src/main/java/com/virtukch/nest/project_member/controller/ProjectMemberController.java
@@ -29,28 +29,17 @@ public class ProjectMemberController {
             - 클라이언트 사이드 드롭다운/선택 UI 구성
 
             ## 응답 데이터
-            사용 가능한 모든 프로젝트 참여 역할을 문자열 배열로 반환:
-            - FRONTEND: 프론트엔드 개발자
-            - BACKEND: 백엔드 개발자
-            - DESIGNER: UI/UX 디자이너
-            - PLANNER: 기획자
-            - DEVOPS: 데브옵스 엔지니어
-            - FULLSTACK: 풀스택 개발자
-            - ANDROID: 안드로이드 개발자
-            - IOS: iOS 개발자
+            사용 가능한 모든 프로젝트 참여 역할(enum)을 문자열 배열로 반환:
+            - BACKEND
+            - FRONTEND
+            - PM
+            - DESIGN
+            - AI
+            - ETC
 
             ## 응답 예시
             ```json
-            [
-                "FRONTEND",
-                "BACKEND",
-                "DESIGNER",
-                "PLANNER",
-                "DEVOPS",
-                "FULLSTACK",
-                "ANDROID",
-                "IOS"
-            ]
+            ["BACKEND", "FRONTEND", "PM", "DESIGN", "AI", "ETC"]
             ```
 
             ## 응답 코드

--- a/src/main/java/com/virtukch/nest/tag/init/TagInitializer.java
+++ b/src/main/java/com/virtukch/nest/tag/init/TagInitializer.java
@@ -93,6 +93,7 @@
 //        Category category = Category.ARTIFICIAL_INTELLIGENCE;
 //        return List.of(
 //                new Tag(category, "AI활용"),
+//                new Tag(category, "AI"),
 //                new Tag(category, "머신러닝•딥러닝"),
 //                new Tag(category, "컴퓨터 비전"),
 //                new Tag(category, "자연어 처리"),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,7 +38,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/프로젝트 모집 테스트 가이드.md
+++ b/프로젝트 모집 테스트 가이드.md
@@ -1,0 +1,182 @@
+이걸# 프로젝트 모집 게시판 Postman 테스트 가이드
+
+이 문서는 Postman으로 프로젝트 모집 기능을 빠르게 검증하기 위한 절차와 예시를 제공합니다.
+
+기본 전제
+- 서버 베이스 URL: `http://localhost:6030` (상황에 맞게 변경)
+- DB(MySQL)는 Docker로 구동 중이며, 애플리케이션도 기동되어 있어야 합니다.
+- 인증이 필요한 요청은 `Authorization: Bearer {access_token}` 헤더가 필요합니다.
+
+Postman 환경 변수 권장
+- `BASE_URL` = `http://localhost:6030`
+- `TOKEN` = 로그인 응답의 `accessToken`
+
+## 1) 회원 가입/로그인 (토큰 확보)
+
+1-1. 회원가입
+- POST `{{BASE_URL}}/api/v1/auth/signup`
+- Body (raw JSON):
+```
+{
+  "email": "tester1@example.com",
+  "password": "P@ssw0rd!",
+  "memberName": "테스터1"
+}
+```
+
+1-2. 로그인 (accessToken 획득)
+- POST `{{BASE_URL}}/api/v1/auth/login`
+- Body (raw JSON):
+```
+{
+  "email": "tester1@example.com",
+  "password": "P@ssw0rd!"
+}
+```
+- 응답의 `accessToken` 값을 `TOKEN` 변수에 저장합니다.
+
+참고: 토큰 유효성 확인 → GET `{{BASE_URL}}/api/v1/auth/me`
+
+## 2) 공개 조회(비인증)
+
+- 프로젝트 목록: GET `{{BASE_URL}}/api/v1/projects`
+- 프로젝트 상세: GET `{{BASE_URL}}/api/v1/projects/1`
+- 역할(enum) 목록: GET `{{BASE_URL}}/api/v1/projects/members`
+
+역할(enum) 값
+- BACKEND, FRONTEND, PM, DESIGN, AI, ETC
+
+## 3) 프로젝트 생성 (v1, JSON)
+
+- POST `{{BASE_URL}}/api/v1/projects/new`
+- Headers: `Authorization: Bearer {{TOKEN}}`, `Content-Type: application/json`
+- Body (예시):
+```
+{
+  "projectTitle": "NEST 팀원 모집",
+  "projectDescription": "커뮤니티 앱 백엔드 개발",
+  "isRecruiting": true,
+  "tags": ["UNCATEGORIZED"],
+  "partCounts": {"BACKEND": 2, "FRONTEND": 2, "PM": 1},
+  "creatorPart": "BACKEND"
+}
+```
+
+가이드
+- `tags`를 생략/빈 배열로 보내면 기본적으로 `UNCATEGORIZED`가 설정됩니다(생성 시).
+- `creatorPart`는 `partCounts`에 포함된 역할 중 하나를 선택하세요(작성자 슬롯 자동 배정 목적).
+
+성공 시
+- 201 Created, `Location: /api/v1/projects/{id}` 헤더 포함
+
+## 4) 프로젝트 생성 (v2, multipart + 이미지)
+
+- POST `{{BASE_URL}}/api/v2/projects`
+- Headers: `Authorization: Bearer {{TOKEN}}`
+- Body (form-data):
+  - key: `projectTitle` → value: `NEST 팀원 모집(이미지)`
+  - key: `projectDescription` → value: `이미지와 함께 올리는 공고`
+  - key: `isRecruiting` → value: `true`
+  - key: `tags` → value: `UNCATEGORIZED` (필요 시 여러 개 추가)
+  - key: `partCounts[BACKEND]` → value: `2`
+  - key: `partCounts[FRONTEND]` → value: `2`
+  - key: `creatorPart` → value: `BACKEND`
+  - key: `images` → type: File, 이미지 파일 첨부(여러 개 가능)
+
+가이드
+- `partCounts`는 `partCounts[역할]=숫자` 형태의 키를 사용합니다.
+- `images`를 여러 개 추가하면 모두 업로드됩니다.
+
+## 5) 프로젝트 수정 (v1, JSON PATCH 규약)
+
+- PATCH `{{BASE_URL}}/api/v1/projects/{projectId}`
+- Headers: `Authorization: Bearer {{TOKEN}}`, `Content-Type: application/json`
+- Body (필요한 필드만 포함):
+```
+{
+  "projectTitle": "제목 부분 수정",     // null/빈문자열 → 미수정
+  "projectDescription": "",            // 빈문자열 → 설명 삭제(null)
+  "isRecruiting": false,               // null → 미수정
+  "tags": ["UNCATEGORIZED"]            // null → 미수정, [] → 태그 전체 제거
+}
+```
+
+주의
+- `tags`를 아예 생략하면 기존 태그 유지, 빈 배열 `[]`이면 전체 제거됩니다.
+
+## 6) 프로젝트 수정 (v2, multipart + 이미지)
+
+- PATCH `{{BASE_URL}}/api/v2/projects/{projectId}`
+- Headers: `Authorization: Bearer {{TOKEN}}`
+- Body (form-data, 필요한 항목만):
+  - `projectTitle` / `projectDescription` / `isRecruiting`
+  - `tags` (여러 개 추가 가능)
+  - `partCounts[BACKEND]` 등(정원 조정)
+  - `images` (첨부 시 전체 교체)
+
+이미지 교체/유지/삭제
+- 유지: `images` 키를 아예 포함하지 않으면 기존 이미지 유지
+- 교체: `images`에 새 파일들을 첨부하면 이전 이미지 전량 삭제 후 새로 저장
+- 전체 삭제: 현재 Postman UI로는 `images` 빈 리스트 전송이 어려워 직접 빈 리스트를 보낼 수 없습니다(한계). 필요 시 별도 `clearImages=true` 같은 플래그 추가 개선을 고려하세요.
+
+## 6-1) 프로젝트 생성/수정 (v3, payload + images 추천)
+
+v3는 multipart에서 JSON을 `payload` 키로 보내고, 파일은 `images`로 보내는 간소화 방식입니다.
+
+- 생성: POST `{{BASE_URL}}/api/v3/projects`
+- 수정: PATCH `{{BASE_URL}}/api/v3/projects/{projectId}`
+- Headers: `Authorization: Bearer {{TOKEN}}`
+- Body (form-data):
+  - key: `payload` (Text) 값 예시:
+```
+{
+  "projectTitle": "NEST 팀원 모집(v3)",
+  "projectDescription": "payload + images 방식",
+  "isRecruiting": true,
+  "tags": ["UNCATEGORIZED"],
+  "slots": [
+    {"part": "BACKEND", "count": 2},
+    {"part": "FRONTEND", "count": 2}
+  ],
+  "creatorPart": "BACKEND"
+}
+```
+  - key: `images` (File, 여러 개 첨부 가능)
+
+가이드
+- `slots` 배열로 역할/정원을 단순히 표현합니다. (기존 `partCounts`도 호환되지만 v3에선 `slots` 권장)
+- 수정 시 `payload.tags`가 null이면 태그 미수정, 빈 배열이면 태그 전체 제거
+- `images` 미포함이면 기존 이미지 유지, 포함하면 전체 교체
+
+## 7) 상세/목록/검색
+
+- 상세: GET `{{BASE_URL}}/api/v1/projects/{projectId}`
+- 목록: GET `{{BASE_URL}}/api/v1/projects`
+- 검색: GET `{{BASE_URL}}/api/v1/projects/search?keyword=스프링&searchType=ALL&tags=UNCATEGORIZED`
+
+검색 옵션
+- `searchType`: ALL(기본) | TITLE | CONTENT
+- 태그 필터는 `tags`를 여러 번 전달하여 다중 적용 가능
+
+## 8) 삭제
+
+- DELETE `{{BASE_URL}}/api/v1/projects/{projectId}`
+- Headers: `Authorization: Bearer {{TOKEN}}`
+- 연관 데이터(태그/댓글/멤버/지원서) 정리 후 삭제됩니다.
+
+## 자주 발생하는 오류와 해결
+
+- 401 Unauthorized
+  - 토큰 누락/만료/불량. 로그인 후 `Authorization: Bearer {{TOKEN}}` 재확인
+
+- 403 Forbidden
+  - 권한 부족(작성자가 아닌 사용자 수정/삭제 시)
+  - 경로 오사용(생성은 `/api/v1/projects/new` 또는 `/api/v2/projects`)
+
+- 400 Bad Request (태그/역할)
+  - 태그가 DB에 없으면 실패 → `UNCATEGORIZED` 사용 또는 사전에 유효 태그 사용
+  - 역할(enum)과 불일치 → BACKEND/FRONTEND/PM/DESIGN/AI/ETC만 허용
+
+팁
+- `creatorPart`는 `partCounts`에 포함된 역할 중 하나로 설정하세요(작성자를 해당 슬롯에 배치).
+- `isRecruiting`은 null이면 미수정, true/false로 보내면 값이 변경됩니다.

--- a/프로젝트 지원_관리 테스트 가이드.md
+++ b/프로젝트 지원_관리 테스트 가이드.md
@@ -1,0 +1,73 @@
+# 프로젝트 지원/관리 Postman 테스트 가이드
+
+기본 전제
+- BASE_URL: `http://localhost:6030`
+- Postman 환경 변수 권장: `BASE_URL`, `TOKEN`
+- 인증이 필요한 모든 API는 `Authorization: Bearer {{TOKEN}}`
+
+## 1) 사전 준비
+
+1) 회원가입/로그인으로 `TOKEN` 확보 (프로젝트 모집 테스트 가이드 참조)
+2) 테스트용 프로젝트 생성
+   - v1 JSON: `POST {{BASE_URL}}/api/v1/projects/new`
+   - v3 payload+images: `POST {{BASE_URL}}/api/v3/projects`
+
+응답의 Location 또는 body에서 `projectId` 확보
+
+## 2) 지원 신청 (지원자 계정으로)
+
+- 경로: `POST {{BASE_URL}}/api/v1/projects/{projectId}/apply`
+- Body(JSON):
+```
+{
+  "projectId": {{projectId}},
+  "part": "BACKEND" // enum: BACKEND|FRONTEND|PM|DESIGN|AI|ETC
+}
+```
+
+유효성
+- 프로젝트 작성자는 지원 불가
+- 이미 멤버이면 지원 불가
+- 모집 중이 아니면 지원 불가
+- 해당 파트 정원이 가득 차면 즉시 차단
+- 중복 지원 방지(대기/수락 상태가 존재하면 불가)
+
+## 3) 지원자 목록 조회 (프로젝트 작성자만)
+
+- 경로: `GET {{BASE_URL}}/api/v1/projects/{projectId}/applications`
+- 설명: 소유자 검증 후 목록 반환 (타인은 400/403 응답)
+
+## 4) 지원 수락/거절 (프로젝트 작성자)
+
+- 수락: `POST {{BASE_URL}}/api/v1/projects/{projectId}/applications/{applicationId}/accept`
+- 거절: `POST {{BASE_URL}}/api/v1/projects/{projectId}/applications/{applicationId}/reject`
+
+수락 결과
+- 지원 상태: ACCEPTED
+- 빈 슬롯을 우선 채움, 없으면 파트 정원 검증 후 멤버 생성
+- 총 정원이 가득 차면 프로젝트 isRecruiting=false 자동 전환
+
+## 5) 내 지원서 목록 (지원자)
+
+- 경로: `GET {{BASE_URL}}/api/v1/projects/applications/me`
+- 설명: 로그인한 사용자의 모든 지원서 목록 반환
+
+## 6) 지원 취소 (지원자)
+
+- 경로: `POST {{BASE_URL}}/api/v1/projects/{projectId}/applications/{applicationId}/cancel`
+- 전제: 본인 소유의 WAITING 상태 지원서만 취소 가능
+- 결과: 상태가 CANCELED로 변경
+
+## 7) 흔한 오류와 해결
+
+- 400: 중복 지원, 처리된 지원서 재처리, 파트 정원 초과, 권한 없음
+- 401: 인증 누락/토큰 만료 → 로그인/토큰 갱신
+- 404: 프로젝트/지원서 없음 → `projectId`, `applicationId` 확인
+
+## 8) 권한 요약
+
+- 지원 신청: 로그인 사용자(작성자 제외)
+- 지원자 목록/수락/거절: 프로젝트 작성자만
+- 내 지원서 목록: 로그인 사용자 본인
+- 지원 취소: 지원자 본인, WAITING 상태만
+


### PR DESCRIPTION
feature/jihyuk: v3(payload+images) 추가, PATCH 규약 정합화, 지원/관리 개선
  - project(v3)
      - ProjectV3Controller 추가: POST/PATCH /api/v3/projects (multipart: payload(JSON)+images)
      - DTO 추가: ProjectUpsertRequest(slots 배열 지원), ProjectSlotDto
      - Service: v3 create/update 및 slots→partCounts 변환(resolvePartCounts)
  - project(v1/v2) 수정
      - PATCH 부분수정 규약 반영:
          - 제목: null/빈 문자열이면 미수정
          - 설명: null=미수정, ""=삭제(null)
          - isRecruiting: null=미수정
      - v2 수정 로직에서 텍스트/모집여부도 요청값 반영, images null이면 유지
      - 태그 갱신 규칙: null=미수정, []=전체 제거, 값 있으면 재설정
      - UNCATEGORIZED 태그 자동 보장(findOrCreateTag)
      - 삭제 시 연관 정리: 댓글(BoardType.PROJECT), 프로젝트 멤버/지원서 제거
      - Location 헤더 교정: /api/v1/projects/{id}
  - enum/문서 정리
      - 역할(enum) 일치: BACKEND, FRONTEND, PM, DESIGN, AI, ETC
      - Controller 주석/예시 업데이트
  - 지원/관리 개선
      - 지원 신청 제약 강화: 모집 종료 시 불가, 이미 멤버면 불가, 파트 정원 가득 시 즉시 차단
      - 지원자 목록 조회 권한: 프로젝트 작성자만
      - 내 지원서 목록: GET /api/v1/projects/applications/me
      - 지원 취소: POST /api/v1/projects/{projectId}/applications/{applicationId}/cancel (WAITING, 본인만)
      - apply 엔드포인트 form-urlencoded 호환 추가(consumes=application/x-www-form-urlencoded)
  - 저장소/코드 보강
      - CommentRepository: deleteAllByBoardTypeAndPostId 추가
      - README 한글화, 테스트 가이드 추가:
          - 프로젝트 모집 테스트 가이드.md
          - 프로젝트 지원_관리 테스트 가이드.md
          - docs/프로젝트_모집_DTO_개선_제안.md


  변경 사항

  - v3 컨트롤러 문서 강화
      - multipart 구조와 form-data 예시, 응답 코드 설명을 Operation에 명시
      - 파일: src/main/java/com/virtukch/nest/project/controller/ProjectV3Controller.java:28, 53
  - DTO 스키마 주석 추가
      - ProjectUpsertRequest/ProjectSlotDto 필드에 @Schema로 설명/예시 부여
      - 파일: src/main/java/com/virtukch/nest/project/dto/ProjectUpsertRequest.java:1, src/main/java/com/virtukch/nest/project/dto/ProjectSlotDto.java:1
      - 지원 요청 DTO(ProjectApplicationRequestDto)에도 스키마 주석 및 projectId 필드 무시 안내
      - 파일: src/main/java/com/virtukch/nest/project_application/dto/ProjectApplicationRequestDto.java:1
  - 지원 apply 엔드포인트 문서/호환
      - consumes를 명시하고, form-urlencoded 전송도 지원하는 별도 메서드 추가
      - 파일: src/main/java/com/virtukch/nest/project_application/controller/ProjectApplicationController.java:1

  새 문서

  - docs/Swagger_프론트엔드_가이드.md:1
      - Swagger 접근 주소, Content-Type 주의점, v1/v2/v3 요약, v3 payload 스키마, PATCH 규약, 지원/관리 요약, 예시 요청/응답 타입, FormData 팁
  - 기존 테스트 문서와 함께 참고
      - 프로젝트 모집 테스트 가이드.md:1
      - 프로젝트 지원_관리 테스트 가이드.md:1